### PR TITLE
[chakra][et_def] change 'strings' field type from 'bytes' to 'string' in AttributeProto

### DIFF
--- a/et_def/et_def.proto
+++ b/et_def/et_def.proto
@@ -45,7 +45,7 @@ message AttributeProto {
   repeated bool bools = 8;
   repeated float floats = 9;
   repeated int64 ints = 10;
-  repeated bytes strings = 11;
+  repeated string strings = 11;
 }
 
 message Node {


### PR DESCRIPTION
Summary: Updated the data type in AttributeProto: Changed 'strings' field from 'repeated bytes' to 'repeated string'.

Reviewed By: lofe

Differential Revision: D47636929