### PR TITLE
[chakra][et_def] add GlobalMetadata to track global metadata

### DIFF
--- a/et_def/et_def.proto
+++ b/et_def/et_def.proto
@@ -48,6 +48,10 @@ message AttributeProto {
   repeated string strings = 11;
 }
 
+message GlobalMetadata {
+  repeated AttributeProto attribute = 1;
+}
+
 message Node {
   required uint64 id = 1;
   required string name = 2;


### PR DESCRIPTION
Summary: While PyTorch execution traces have global metadata such as schema, pid, time, and start_ts, Chakra execution traces do not. I have introduced the ExecutionTrace message to track global metadata.

Reviewed By: zhaodongwang

Differential Revision: D47795237