### PR TITLE
[chakra][et_converter] support Tensor(long int) in get_data_type_size

### DIFF
--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -120,6 +120,7 @@ class PyTorch2ChakraConverter:
                 "Tensor(long)": 8,
                 "Tensor(c10::Half)": 2,
                 "Tensor(unsigned char)": 1,
+                "Tensor(long int)": 8,
         }
         try:
             data_type_size = data_type_size_dict[data_type]


### PR DESCRIPTION
Summary: This commit enhances the get_data_type_size function to accommodate Tensor(long int).

Reviewed By: shengbao

Differential Revision: D48032036