### PR TITLE
[chakra][et_jsonizer] add et_jsonizer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -138,3 +138,12 @@ $ python -m utils.et_generator.et_generator\
 $ cd -
 $ ./run.sh
 ```
+
+## Execution Trace Jsonizer (et_jsonizer)
+This tool prints the nodes within execution traces for better comprehension.
+The printed information includes the node's id, name, type, and any associated metadata, which are all outputted in a user-friendly text format.
+```
+$ python -m et_jsonizer.et_jsonizer\
+    --input_filename <input_filename>\
+    --output_filename <output_filename>
+```

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def main():
         f"{package_base}.et_def": "et_def",
         f"{package_base}.et_converter": "et_converter",
         f"{package_base}.et_generator": "utils/et_generator",
+        f"{package_base}.et_jsonizer": "utils/et_jsonizer",
         f"{package_base}.et_visualizer": "et_visualizer",
         f"{package_base}.timeline_visualizer": "timeline_visualizer"
     }

--- a/utils/et_jsonizer/et_jsonizer.py
+++ b/utils/et_jsonizer/et_jsonizer.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from google.protobuf.json_format import MessageToJson
+
+from third_party.utils.protolib import (
+    openFileRd as open_file_rd,
+    decodeMessage as decode_message
+)
+
+from et_def.et_def_pb2 import (
+    Node as ChakraNode,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Execution Trace Jsonizer"
+    )
+    parser.add_argument(
+        "--input_filename",
+        type=str,
+        default=None,
+        required=True,
+        help="Input Chakra execution trace filename"
+    )
+    parser.add_argument(
+        "--output_filename",
+        type=str,
+        default=None,
+        required=True,
+        help="Output filename"
+    )
+    args = parser.parse_args()
+
+    et = open_file_rd(args.input_filename)
+    node = ChakraNode()
+    with open(args.output_filename, 'w') as f:
+        while decode_message(et, node):
+            f.write(MessageToJson(node))
+    et.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary: This commit introduces the Execution Trace Jsonizer (`et_jsonizer `). The `et_jsonizer` tool is designed to improve the readability of execution traces by printing node details into a json file. The details include each node's `id`, `name`, `type`, and associated `metadata`.

Reviewed By: lofe

Differential Revision: D47645266