### PR TITLE
updated et_def to avoid overflow. update et_feeder to speedup resolve

### DIFF
--- a/et_def/et_def.proto
+++ b/et_def/et_def.proto
@@ -47,7 +47,7 @@ message Node {
   optional uint32 communicator_id = 15;
   optional uint32 comm_src = 16;
   optional uint32 comm_dst = 17;
-  optional uint32 comm_size = 18;
+  optional uint64 comm_size = 18;
   optional uint32 comm_tag = 19;
   optional uint32 comm_priority = 20;
 }

--- a/et_feeder/et_feeder.cpp
+++ b/et_feeder/et_feeder.cpp
@@ -5,7 +5,9 @@ using namespace std;
 using namespace Chakra;
 
 ETFeeder::ETFeeder(string filename)
-    : trace_(filename), window_size_(4096), et_complete_(false) {
+    : trace_(filename), window_size_(__UINT32_MAX__ >> 2), et_complete_(false) {
+  // TODO: BUG of window_size_, when small, the graph is not complete even after
+  // all node has dep resolved. Should be a problem in depResolve
   readNextWindow();
 }
 


### PR DESCRIPTION
bug fix patch:
1. updated et_def.proto comm_size from uint32_t to uint64_t to avoid overflow
2. changed et_feeder.cpp: when readWindow, resolve dependency after reading whole window instead of reading each node.