### PR TITLE
Fix AttributeError: 'PyTorch2ChakraConverter' object has no attribute…

### DIFF
--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -472,7 +472,7 @@ class PyTorch2ChakraConverter:
         Run DFS on a root node and phase root nodes as they may have CPU operators.
         DFS populates pt_cpu_node_dict and returns the largest NID within the phase.
         """
-        root_nid = self.find_root_nid(self.pt_nodes)
+        root_nids = self.find_root_nids(self.pt_nodes)
         for node in self.pt_nodes:
             if self.is_phase_root_node(root_nids, node):
                 largest_nid_within_phase = self.dfs(node, root_nids)


### PR DESCRIPTION
Following README.md from the astra-sim repo
https://github.com/astra-sim/astra-sim/blob/d566bb0f3dfa008526d7ff627bc4a9fa5ceeada4/README.md?plain=1#L260
```bash
$ python3 -m et_converter.et_converter    --input_type PyTorch    --input_filename et_plus/dlrm_eg_0_plus.json    --output_filename et_plus/dlrm_chakra.0.et    --num_dims 1 
Traceback (most recent call last):
  File "/opt/astra-sim/extern/graph_frontend/chakra/et_converter/et_converter.py", line 121, in main
    converter.convert()
  File "/opt/astra-sim/extern/graph_frontend/chakra/et_converter/pytorch2chakra_converter.py", line 859, in convert
    self.discover_pytorch_cpu_ops()
  File "/opt/astra-sim/extern/graph_frontend/chakra/et_converter/pytorch2chakra_converter.py", line 475, in discover_pytorch_cpu_ops
    root_nid = self.find_root_nid(self.pt_nodes)
AttributeError: 'PyTorch2ChakraConverter' object has no attribute 'find_root_nid'
```
This PR fixes the AttributeError introduced in commit https://github.com/mlcommons/chakra/commit/ebcdfdb69756dab7eef04a57bdd0609f8009664e.