### PR TITLE
[ETFeeder] Speedup et_feeder and resolve uninitialized attrs values in ETFeederNode

### DIFF
--- a/et_feeder/et_feeder.cpp
+++ b/et_feeder/et_feeder.cpp
@@ -144,17 +144,21 @@ void ETFeeder::readNextWindow() {
   }
   uint32_t num_read = 0;
   do {
-    shared_ptr<ETFeederNode> new_node = readNode();
-    if (new_node == nullptr) {
-      et_complete_ = true;
-      break;
+    if (this->et_complete_) {
+      // graph read finished, but still nodes unresolved
+      // which means the graph is broken
+      assert(false);
     }
-
-    addNode(new_node);
-    ++num_read;
-
+    for (uint32_t num_read = 0; num_read < this->window_size_; num_read++) {
+      std::shared_ptr<ETFeederNode> new_node = readNode();
+      if (new_node == nullptr) {
+        et_complete_ = true;
+        break;
+      }
+      addNode(new_node);
+    }
     resolveDep();
-  } while ((num_read < window_size_) || (dep_unresolved_node_set_.size() != 0));
+  } while (dep_unresolved_node_set_.size() != 0);
 
   for (auto node_id_node : dep_graph_) {
     uint64_t node_id = node_id_node.first;

--- a/et_feeder/et_feeder_node.h
+++ b/et_feeder/et_feeder_node.h
@@ -47,21 +47,22 @@ class ETFeederNode {
   std::vector<std::shared_ptr<ETFeederNode>> children_vec_{};
   std::vector<uint64_t> dep_unresolved_parent_ids_{};
 
-  uint64_t id_;
-  std::string name_;
-  bool is_cpu_op_;
-  uint64_t runtime_;
-  uint64_t num_ops_;
-  uint32_t tensor_loc_;
-  uint64_t tensor_size_;
-  ChakraProtoMsg::CollectiveCommType comm_type_;
-  uint32_t involved_dim_size_;
+  uint64_t id_ = 0ul;
+  std::string name_ = "";
+  bool is_cpu_op_ = false;
+  uint64_t runtime_ = 0ul;
+  uint64_t num_ops_ = 0ul;
+  uint32_t tensor_loc_ = 0u;
+  uint64_t tensor_size_ = 0ul;
+  ChakraProtoMsg::CollectiveCommType comm_type_ =
+      ChakraProtoMsg::CollectiveCommType::BROADCAST;
+  uint32_t involved_dim_size_ = 0u;
   std::vector<bool> involved_dim_;
-  uint32_t comm_priority_;
-  uint64_t comm_size_;
-  uint32_t comm_src_;
-  uint32_t comm_dst_;
-  uint32_t comm_tag_;
+  uint32_t comm_priority_ = 0u;
+  uint64_t comm_size_ = 0ul;
+  uint32_t comm_src_ = 0u;
+  uint32_t comm_dst_ = 0u;
+  uint32_t comm_tag_ = 0u;
 };
 
 } // namespace Chakra


### PR DESCRIPTION
1. Updated ETFeeder::readNextWindow to speed up by removing some extra resolveDeps() calls.
2. Assigned default values of attrs in ETFeederNode to avoid uninitialized variables and leading undefined behavior with -O3 compile flag.