### PR TITLE
Enhance error handling in ETFeeder::lookupNode with detailed exception messages

### DIFF
--- a/et_feeder/et_feeder.cpp
+++ b/et_feeder/et_feeder.cpp
@@ -54,7 +54,13 @@ void ETFeeder::pushBackIssuableNode(uint64_t node_id) {
 }
 
 shared_ptr<ETFeederNode> ETFeeder::lookupNode(uint64_t node_id) {
-  return dep_graph_[node_id];
+  try {
+    return dep_graph_.at(node_id);
+  } catch (const std::out_of_range& e) {
+    std::cerr << "looking for node_id=" << node_id
+              << " in dep graph, however, not loaded yet" << std::endl;
+    throw(e);
+  }
 }
 
 void ETFeeder::freeChildrenNodes(uint64_t node_id) {


### PR DESCRIPTION
## Summary
This PR introduces a significant improvement in error handling within the ETFeeder::lookupNode method. By catching and handling std::out_of_range exceptions, the update ensures that any attempt to access a non-existent node ID in the dependency graph is met with a clear and informative error message.

## Test Plan
```
$ cd ~/param
$ cd param/train/comms/pt
$ pip install .
$ cd ../../compute/python
$ pip install -r requirements.txt
$ python setup.py install
$ python tools/trace_link.py --pytorch-et-file ~/llama_pytorch_et/llama_et_0.json --kineto-file ~/llama_kineto/worker0_step_12.1697596714999.pt.trace.json --output-file ~/rank0.json

$ cd ~/charka
$ pip install .
$ python3 -m chakra.et_converter.et_converter --input_type PyTorch --input_filename ~/rank0.json --output_filename ~/rank0.chakra --num_dims 1 
$ cp ~/rank0.chakra chakra.0.et && cp chakra.0.et chakra.1.et

$ cd ~/astra-sim
$ ./build/astra_analytical/build.sh
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware\
  --workload-configuration=/Users/theo/chakra/chakra\
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
sys[0] finished, 7269182000 cycles
sys[1] finished, 7269182000 cycles
```