### PR TITLE
[chakra][et_converter] Add annotation for Graph Trace Observer in PyTorch

### DIFF
--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -382,6 +382,8 @@ class PyTorch2ChakraConverter:
         for node in nodes:
             if "[pytorch|profiler|execution_graph|thread]" in node["name"]:
                 root_nids.append(node["id"])
+            elif "[pytorch|profiler|execution_trace|thread]" in node["name"]:
+                root_nids.append(node["id"])
         if not root_nids:
             raise ValueError("Cannot find a root NID")
         return root_nids


### PR DESCRIPTION
## Test
This has been tested with the latest Chakra in Ubuntu 22.04 machine. 
The traces are from Resnet-50 distributed data parallel with Graph trace observer. 