### PR TITLE
[chakra][et_converter] Add Annotation for Graph Trace Observer in PyTorch

### DIFF
--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -382,6 +382,8 @@ class PyTorch2ChakraConverter:
         for node in nodes:
             if "[pytorch|profiler|execution_graph|thread]" in node["name"]:
                 root_nids.append(node["id"])
+            elif "[pytorch|profiler|execution_trace|thread]" in node["name"]:
+                root_nids.append(node["id"])
         if not root_nids:
             raise ValueError("Cannot find a root NID")
         return root_nids


### PR DESCRIPTION
## Summary
- This has been tested with the latest Chakra on an Ubuntu 22.04 machine.
- The traces are from Resnet-50, distributed data parallel, with a Graph Trace Observer.
- This PR adds annotations for handling the traces.  

## Test Plan

Chakra
```
python3 -m chakra.et_converter.et_converter --input_type PyTorch --input_filename result/eg.rank_0.pt.trace_plus.json --output_filename et_plus/chakra.0.et --num_dims 1
python3 -m chakra.et_converter.et_converter --input_type PyTorch --input_filename result/eg.rank_1.pt.trace_plus.json --output_filename et_plus/chakra.1.et --num_dims 1
```
Astra-sim
```
./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware --workload-configuration=./extern/graph_frontend/chakra/et_plus/chakra --system-configuration=./inputs/system/FullyConnected.json --network-configuration=./inputs/network/analytical/FullyConnected.yml --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
```
