### PR TITLE
et_feeder: Bugfix in attr parsing in et_feeder

### DIFF
--- a/et_feeder/et_feeder_node.cpp
+++ b/et_feeder/et_feeder_node.cpp
@@ -8,30 +8,36 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
   this->id_ = node->id();
   this->name_ = node->name();
   this->runtime_ = node->duration_micros();
-  this->is_cpu_op_ = true;
-  for (int i = 0; i < node->attr_size(); i++) {
-    string attr_name = node->attr(i).name();
+  this->is_cpu_op_ = 1;
+
+  for (const auto& attr : node->attr()) {
+    const string& attr_name = attr.name();
+
     if (attr_name == "is_cpu_op") {
-      assign_attr_val(node, i, (void*)(&is_cpu_op_));
+      this->is_cpu_op_ = static_cast<uint32_t>(attr.int32_val());
     } else if (attr_name == "num_ops") {
-      assign_attr_val(node, i, (void*)(&num_ops_));
+      this->num_ops_ = static_cast<uint64_t>(attr.int64_val());
     } else if (attr_name == "tensor_size") {
-      assign_attr_val(node, i, (void*)(&tensor_size_));
+      this->tensor_size_ = attr.uint64_val();
     } else if (attr_name == "comm_type") {
-      assign_attr_val(node, i, (void*)(&comm_type_));
+      this->comm_type_ =
+          static_cast<ChakraProtoMsg::CollectiveCommType>(attr.int64_val());
     } else if (attr_name == "involved_dim") {
-      assign_attr_val(node, i, (void*)(&involved_dim_));
-      involved_dim_size_ = node->attr(i).bool_list().values_size();
+      this->involved_dim_.clear();
+      for (const bool val : attr.bool_list().values()) {
+        this->involved_dim_.push_back(val);
+      }
+      this->involved_dim_size_ = this->involved_dim_.size();
     } else if (attr_name == "comm_priority") {
-      assign_attr_val(node, i, (void*)(&comm_priority_));
+      this->comm_priority_ = static_cast<uint32_t>(attr.int32_val());
     } else if (attr_name == "comm_size") {
-      assign_attr_val(node, i, (void*)(&comm_size_));
+      this->comm_size_ = attr.int64_val();
     } else if (attr_name == "comm_src") {
-      assign_attr_val(node, i, (void*)(&comm_src_));
+      this->comm_src_ = static_cast<uint32_t>(attr.int32_val());
     } else if (attr_name == "comm_dst") {
-      assign_attr_val(node, i, (void*)(&comm_dst_));
+      this->comm_dst_ = static_cast<uint32_t>(attr.int32_val());
     } else if (attr_name == "comm_tag") {
-      assign_attr_val(node, i, (void*)(&comm_tag_));
+      this->comm_tag_ = static_cast<uint32_t>(attr.int32_val());
     }
   }
 }
@@ -65,140 +71,6 @@ vector<uint64_t> ETFeederNode::getDepUnresolvedParentIDs() {
 void ETFeederNode::setDepUnresolvedParentIDs(
     vector<uint64_t> const& dep_unresolved_parent_ids) {
   dep_unresolved_parent_ids_ = dep_unresolved_parent_ids;
-}
-
-void ETFeederNode::assign_attr_val(
-    shared_ptr<ChakraProtoMsg::Node> node,
-    int i,
-    void* member) {
-  auto attr = node->attr(i);
-  switch (attr.value_case()) {
-    case ChakraProtoMsg::AttributeProto::kDoubleVal:
-      *((double*)member) = attr.double_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kDoubleList:
-      for (const auto& val : attr.double_list().values()) {
-        (*((std::vector<double>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kFloatVal:
-      *((float*)member) = attr.float_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kFloatList:
-      for (const auto& val : attr.float_list().values()) {
-        (*((std::vector<float>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kInt32Val:
-      *((int32_t*)member) = attr.int32_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kInt32List:
-      for (const auto& val : attr.int32_list().values()) {
-        (*((std::vector<int32_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kInt64Val:
-      *((int64_t*)member) = attr.int64_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kInt64List:
-      for (const auto& val : attr.int64_list().values()) {
-        (*((std::vector<int64_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kUint32Val:
-      *((uint32_t*)member) = attr.uint32_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kUint32List:
-      for (const auto& val : attr.uint32_list().values()) {
-        (*((std::vector<uint32_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kUint64Val:
-      *((uint64_t*)member) = attr.uint64_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kUint64List:
-      for (const auto& val : attr.uint64_list().values()) {
-        (*((std::vector<uint64_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kSint32Val:
-      *((int32_t*)member) = attr.sint32_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kSint32List:
-      for (const auto& val : attr.sint32_list().values()) {
-        (*((std::vector<int32_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kSint64Val:
-      *((int64_t*)member) = attr.sint64_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kSint64List:
-      for (const auto& val : attr.sint64_list().values()) {
-        (*((std::vector<int64_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kFixed32Val:
-      *((uint32_t*)member) = attr.fixed32_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kFixed32List:
-      for (const auto& val : attr.fixed32_list().values()) {
-        (*((std::vector<uint32_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kFixed64Val:
-      *((uint64_t*)member) = attr.fixed64_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kFixed64List:
-      for (const auto& val : attr.fixed64_list().values()) {
-        (*((std::vector<uint64_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kSfixed32Val:
-      *((int32_t*)member) = attr.sfixed32_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kSfixed32List:
-      for (const auto& val : attr.sfixed32_list().values()) {
-        (*((std::vector<int32_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kSfixed64Val:
-      *((int64_t*)member) = attr.sfixed64_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kSfixed64List:
-      for (const auto& val : attr.sfixed64_list().values()) {
-        (*((std::vector<int64_t>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kBoolVal:
-      *((bool*)member) = attr.bool_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kBoolList:
-      for (const auto& val : attr.bool_list().values()) {
-        (*((std::vector<bool>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kStringVal:
-      *((std::string*)member) = attr.string_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kStringList:
-      for (const auto& val : attr.string_list().values()) {
-        (*((std::vector<std::string>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::kBytesVal:
-      *((std::string*)member) = attr.bytes_val();
-      break;
-    case ChakraProtoMsg::AttributeProto::kBytesList:
-      for (const auto& val : attr.bytes_list().values()) {
-        (*((std::vector<std::string>*)member)).push_back(val);
-      }
-      break;
-    case ChakraProtoMsg::AttributeProto::VALUE_NOT_SET:
-    default:
-      std::cerr << "undefined attr type in chakra node" << std::endl;
-      exit(EXIT_FAILURE);
-      break;
-  }
 }
 
 uint64_t ETFeederNode::id() {

--- a/et_feeder/et_feeder_node.h
+++ b/et_feeder/et_feeder_node.h
@@ -49,7 +49,7 @@ class ETFeederNode {
 
   uint64_t id_;
   std::string name_;
-  bool is_cpu_op_;
+  uint32_t is_cpu_op_;
   uint64_t runtime_;
   uint64_t num_ops_;
   uint32_t tensor_loc_;

--- a/et_visualizer/et_visualizer.py
+++ b/et_visualizer/et_visualizer.py
@@ -3,6 +3,7 @@
 import argparse
 import graphviz
 import networkx as nx
+import re
 
 from chakra.third_party.utils.protolib import (
     openFileRd as open_file_rd,
@@ -12,6 +13,22 @@ from chakra.et_def.et_def_pb2 import (
     GlobalMetadata,
     Node,
 )
+
+
+def escape_label(label: str) -> str:
+    """
+    Escapes special characters in labels for graph rendering.
+
+    Args:
+        label (str): The original label string.
+
+    Returns:
+        str: The escaped label string.
+    """
+    # Define special characters to escape
+    special_chars = "{}()<>\[\]|&-"
+    # Escape special characters
+    return re.sub(f"([{special_chars}])", r"\\\1", label)
 
 
 def main() -> None:
@@ -43,8 +60,9 @@ def main() -> None:
         f = graphviz.Digraph()
         decode_message(et, gm)
         while decode_message(et, node):
+            escaped_label = escape_label(node.name)
             f.node(name=f"{node.id}",
-                   label=f"{node.name}",
+                   label=escaped_label,
                    id=str(node.id),
                    shape="record")
 


### PR DESCRIPTION
## Summary
This pull request updates the `et_feeder` module to fix a critical parsing issue. The problem stemmed from two main sources: inadequate support in protobuf for the `oneof` boolean value, and a bug within the `ETFeederNode::assign_attr_val` function.

## Test Plan
```
$ cd ~/param
$ cd param/train/comms/pt
$ pip install .
$ cd ../../compute/python
$ pip install -r requirements.txt
$ python setup.py install
$ python tools/trace_link.py --pytorch-et-file ~/llama_pytorch_et/llama_et_0.json --kineto-file ~/llama_kineto/worker0_step_12.1697596714999.pt.trace.json --output-file ~/rank0.json

$ cd ~/charka
$ pip install .
$ python3 -m chakra.et_converter.et_converter --input_type PyTorch --input_filename ~/rank0.json --output_filename ~/rank0.chakra --num_dims 1 
$ cp ~/rank0.chakra chakra.0.et && cp chakra.0.et chakra.1.et

$ cd ~/astra-sim
$ ./build/astra_analytical/build.sh
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware\
  --workload-configuration=/Users/theo/chakra/chakra\
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
ring of node 0, id: 0 dimension: local total nodes in ring: 2 index in ring: 0 offset: 1total nodes in ring: 2
sys[0] finished, 7269182000 cycles
sys[1] finished, 7269182000 cycles
```