### PR TITLE
et_jsonizer: Refactor et_jsonizer

### DIFF
--- a/utils/et_jsonizer/et_jsonizer.py
+++ b/utils/et_jsonizer/et_jsonizer.py
@@ -17,33 +17,31 @@ from chakra.et_def.et_def_pb2 import (
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Execution Trace Jsonizer"
+        description="Converts Chakra execution trace to JSON format."
     )
     parser.add_argument(
         "--input_filename",
         type=str,
-        default=None,
         required=True,
-        help="Input Chakra execution trace filename"
+        help="Specifies the input filename of the Chakra execution trace."
     )
     parser.add_argument(
         "--output_filename",
         type=str,
-        default=None,
         required=True,
-        help="Output filename"
+        help="Specifies the output filename for the JSON data."
     )
     args = parser.parse_args()
 
-    et = open_file_rd(args.input_filename)
+    execution_trace = open_file_rd(args.input_filename)
     node = ChakraNode()
-    with open(args.output_filename, 'w') as f:
-        gm = GlobalMetadata()
-        decode_message(et, gm)
-        f.write(MessageToJson(gm))
-        while decode_message(et, node):
-            f.write(MessageToJson(node))
-    et.close()
+    with open(args.output_filename, 'w') as file:
+        global_metadata = GlobalMetadata()
+        decode_message(execution_trace, global_metadata)
+        file.write(MessageToJson(global_metadata))
+        while decode_message(execution_trace, node):
+            file.write(MessageToJson(node))
+    execution_trace.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Updated et_jsonizer for readability and maintainability.

## Test Plan
```
$ pip install .
$ python3 -m chakra.et_jsonizer.et_jsonizer --input_filename ~/rank0.chakra --output_filename ~/rank0.chakra.json
$ tail ~/rank0.chakra.json
    {
      "name": "is_cpu_op",
      "int32Val": 0
    },
    {
      "name": "ts",
      "int64Val": "1697596710335517"
    }
  ]
}%               
```