### PR TITLE
Convert synchronization dependency to data dependency

### DIFF
--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -677,6 +677,16 @@ class PyTorch2ChakraConverter:
                                 f"dependency on Node ID {id}"
                             )
 
+                if pytorch_node.sync_dep:
+                    for orig_id in pytorch_node.sync_dep:
+                        for id in self.id_assigner.get_assigned_ids(orig_id):
+                            if id not in current_node.data_deps:
+                                current_node.data_deps.append(id)
+                                self.logger.debug(
+                                    f"Node ID {current_node.id} now has an synchronization "
+                                    f"dependency on Node ID {id}"
+                                )
+
                 if last_visited_non_gpu:
                     if last_visited_non_gpu.id not in current_node.data_deps:
                         current_node.data_deps.append(last_visited_non_gpu.id)

--- a/et_converter/pytorch_node.py
+++ b/et_converter/pytorch_node.py
@@ -463,6 +463,17 @@ class PyTorchNode:
         return self.node_data.get("inter_thread_dep")
 
     @property
+    def sync_dep(self) -> Optional[List[int]]:
+        """
+        Returns the synchronization dependency value of the node, if available.
+
+        Returns:
+            Optional[int]: The synchronization dependency value or None if not
+                           available.
+        """
+        return self.node_data.get("sync_dep")
+
+    @property
     def stream(self) -> int:
         return self.node_data["stream"]
 


### PR DESCRIPTION
## Summary
This update is for considering synchronization dependency we can extract from Holistic Trace Analysis (HTA, https://github.com/facebookresearch/HolisticTraceAnalysis)

It uses new input field for Chakra converter, 'sync_dep'. 
Required updates are developing on forked repo (https://github.com/JoongunPark/param/tree/refactor)
The updates will be sent as PR to Param (https://github.com/facebookresearch/param) or Taekyung's forked repo (https://github.com/TaekyungHeo/param/tree/refactor)

## Test Plan

Command haven't changed. 

```
# Install package from source
$ pip install .

# Run converter 
python3 -m chakra.et_converter.et_converter\
    --input_type PyTorch\
    --input_filename ./result/rank_0.json\
    --output_filename ./result/rank_0.et\
    --num_dims 1
```

Tested input from Resnet-50 with GTX1070 (rank 0)
[rank_0.json](https://github.com/mlcommons/chakra/files/14453986/rank_0.json)

Tested output (Zipped)
[rank_0.zip](https://github.com/mlcommons/chakra/files/14454038/rank_0.zip)



