### PR TITLE
Modules calling simplified

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
       - run: conda install pytorch
       - run: pip install fbgemm-gpu-cpu
       - run: pip install .
-      - run: python3 -m chakra.et_generator.et_generator --num_npus 1
+      - run: chakra_generator --num_npus 1
       - run: |
-          python3 -m chakra.et_visualizer.et_visualizer --help
+          chakra_visualizer --help
           for f in *.et
           do
-              python3 -m chakra.et_visualizer.et_visualizer --input_filename ${f} --output_filename "${f%.*}".dot
+              chakra_visualizer --input_filename ${f} --output_filename "${f%.*}".dot
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: make gcc g++ libprotobuf-dev protobuf-compiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,10 @@ Repository = "https://github.com/mlcommons/chakra.git"
 
 [tool.setuptools.package-data]
 "chakra.et_def" = ["et_def_pb2.pyi", "et_def.proto"]
+
+[project.scripts]
+chakra_converter = "chakra.et_converter.et_converter:main"
+chakra_visualizer = "chakra.et_visualizer.et_visualizer:main"
+chakra_timeline_visualizer = "chakra.et_timeline_visualizer.et_timeline_visualizer:main"
+chakra_generator = "chakra.et_generator.et_generator:main"
+chakra_jsonizer = "chakra.et_jsonizer.et_jsonizer:main"


### PR DESCRIPTION
## Summary
This PR is intended to  simplify the modules calling. It has the following additions:

- updates the github checkout action to the last version
- offers a solution to that redundancy problem when calling modules. For this, the pyproject.toml file was enhanced and the structure of the project was not modified.
- now the user can call a module like this: 

> chakra_generator --num_npus 1

instead of 

> python3 -m chakra.et_generator.et_generator --num_npus 1

- also, the old syntax is still available
- updates the main.yml workflow example to match the new syntax


## Test Plan
Tested locally after installing the package. 
Tested to see if it behaves the same as the previous approach of calling modules.
