### PR TITLE
Ignore trace_link.py and test_trace_link.py in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ chakra_jsonizer = "chakra.et_jsonizer.et_jsonizer:main"
 [tool.ruff]
 target-version = "py39"
 line-length = 120
+exclude = [
+    "trace_link.py",
+    "test_trace_link.py",
+]
 
 [tool.ruff.lint]
 select = ["I", "B", "E", "F", "SIM", "W", "C90", "EXE"]


### PR DESCRIPTION
## Summary
Ignore trace_link.py and test_trace_link.py in ruff

## Test Plan
GitHub actions are passing.