### PR TITLE
Fix bugs in et_converter

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -4,5 +4,9 @@
     "et_converter",
     "utils"
   ],
-  "search_path": ["/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages"]
+  "search_path": ["/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages"],
+  "ignore_all_errors": [
+    "et_converter/pytorch2chakra_converter.py",
+    "et_converter/pytorch_node.py"
+  ]
 }

--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -105,7 +105,7 @@ class PyTorch2ChakraConverter:
                     chakra_gpu_node = self.convert_to_chakra_node(pytorch_gpu_node)
 
                     if chakra_node.type == COMM_COLL_NODE:
-                        collective_comm_type = self.get_collective_comm_type(pytorch_node.name)
+                        collective_comm_type = self.get_collective_comm_type(pytorch_gpu_node.name)
                         chakra_gpu_node.attr.extend(
                             [
                                 ChakraAttr(name="comm_type", int64_val=collective_comm_type),
@@ -316,19 +316,18 @@ class PyTorch2ChakraConverter:
             int: The collective communication type of the node.
         """
         comm_type_mapping = {
-            "all_reduce": ALL_REDUCE,
-            "all_to_all": ALL_TO_ALL,
-            "all_gather": ALL_GATHER,
-            "reduce_scatter": REDUCE_SCATTER,
+            "allreduce": ALL_REDUCE,
+            "alltoall": ALL_TO_ALL,
+            "allgather": ALL_GATHER,
+            "reducescatter": REDUCE_SCATTER,
             "broadcast": BROADCAST,
-            "AllReduce": ALL_REDUCE,
-            "Broadcast": BROADCAST,
             # Additional cases can be added here
         }
 
-        for key, value in comm_type_mapping.items():
-            if key.lower() in name.lower():
-                return value
+        normalized_name = name.replace("_", "").replace("-", "").lower()
+        for key in comm_type_mapping:
+            if key in normalized_name:
+                return comm_type_mapping[key]
 
         raise ValueError(
             f"'{name}' not found in collective communication mapping. "

--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -605,7 +605,7 @@ class PyTorch2ChakraConverter:
 
         for node_id in self.chakra_nodes:
             if dfs(node_id, []):
-                raise Exception(f"Cyclic dependency detected starting from node " f"{self.chakra_nodes[node_id].name}")
+                raise Exception(f"Cyclic dependency detected starting from node {self.chakra_nodes[node_id].name}")
 
     def write_chakra_et(self) -> None:
         """
@@ -722,14 +722,14 @@ class PyTorch2ChakraConverter:
                 current_cpu_node
                 and current_time - current_cpu_node[1] >= self.chakra_nodes[current_cpu_node[0]].duration_micros
             ):
-                self.logger.info(f"CPU Node ID {current_cpu_node[0]} completed " f"at {current_time}us")
+                self.logger.info(f"CPU Node ID {current_cpu_node[0]} completed at {current_time}us")
                 current_cpu_node = None
 
             if (
                 current_gpu_node
                 and current_time - current_gpu_node[1] >= self.chakra_nodes[current_gpu_node[0]].duration_micros
             ):
-                self.logger.info(f"GPU Node ID {current_gpu_node[0]} completed " f"at {current_time}us")
+                self.logger.info(f"GPU Node ID {current_gpu_node[0]} completed at {current_time}us")
                 current_gpu_node = None
 
             for node_id in list(issued_nodes):

--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -21,61 +21,6 @@ from chakra.et_def.et_def_pb2 import (
 )
 
 
-class UniqueIdAssigner:
-    """
-    Class for assigning unique IDs. Generates a new unique ID for each call,
-    even with the same original ID, and keeps track of all assigned IDs.
-
-    Attributes:
-        next_id (int): The next available unique ID.
-        original_to_assigned_ids (Dict[int, List[int]]): Mapping from original
-            IDs to lists of assigned unique IDs.
-    """
-
-    def __init__(self) -> None:
-        self.next_id = 0
-        self.original_to_assigned_ids: Dict[int, List[int]] = {}
-
-    def set_next_id(self, next_id: int) -> None:
-        """
-        Sets the starting next unique ID.
-
-        Args:
-            next_id (int): The starting next unique ID to set.
-        """
-        self.next_id = next_id
-
-    def assign_unique_id(self, original_id: int) -> int:
-        """
-        Generates and tracks a new unique ID for each call for a given original ID.
-
-        Args:
-            original_id (int): The original ID to generate a unique ID for.
-
-        Returns:
-            int: A new unique ID for the original ID.
-        """
-        unique_id = self.next_id
-        self.next_id += 1
-
-        assigned_ids = self.original_to_assigned_ids.setdefault(original_id, [])
-        assigned_ids.append(unique_id)
-
-        return unique_id
-
-    def get_assigned_ids(self, original_id: int) -> List[int]:
-        """
-        Retrieves all unique IDs assigned to a given original ID.
-
-        Args:
-            original_id (int): The original ID to retrieve unique IDs for.
-
-        Returns:
-            List[int]: List of unique IDs assigned to the original ID.
-        """
-        return self.original_to_assigned_ids.get(original_id, [])
-
-
 class PyTorch2ChakraConverter:
     """
     Converter class for transforming PyTorch execution traces into Chakra format.
@@ -90,7 +35,6 @@ class PyTorch2ChakraConverter:
         output_filename (str): Output file name for the converted Chakra trace.
         chakra_et(IO[bytes]): File handle for the Chakra execution trace output file.
         logger (logging.Logger): Logger for logging information during conversion.
-        id_assigner (UniqueIdAssigner): Object to manage unique ID assignments.
         pytorch_schema (Optional[str]): Schema info of the PyTorch trace.
         pytorch_pid (Optional[int]): Process ID associated with the PyTorch trace.
         pytorch_time (Optional[str]): Time info of the PyTorch trace.
@@ -122,7 +66,6 @@ class PyTorch2ChakraConverter:
         self.output_filename = output_filename
         self.chakra_et = None
         self.logger = logger
-        self.id_assigner = UniqueIdAssigner()
         self.initialize_attributes()
 
     def initialize_attributes(self) -> None:
@@ -203,7 +146,6 @@ class PyTorch2ChakraConverter:
             with open(self.input_filename, "r") as pytorch_et:
                 pytorch_et_data = json.load(pytorch_et)
             self._parse_and_instantiate_nodes(pytorch_et_data)
-            self.id_assigner.set_next_id(max(self.pytorch_nodes.keys()) + 1)
         except IOError as e:
             self.logger.error(f"Error opening file {self.input_filename}: {e}")
             raise Exception(f"Could not open file {self.input_filename}")
@@ -501,13 +443,12 @@ class PyTorch2ChakraConverter:
                 last_visited_any = current_node
             else:
                 if pytorch_node.inter_thread_dep:
-                    for id in self.id_assigner.get_assigned_ids(pytorch_node.inter_thread_dep):
-                        if id not in current_node.data_deps:
-                            current_node.data_deps.append(id)
-                            self.logger.debug(
-                                f"CPU Node ID {current_node.id} now has an inter-thread data "
-                                f"dependency on Node ID {id}"
-                            )
+                    id = pytorch_node.inter_thread_dep
+                    if id not in current_node.data_deps:
+                        current_node.data_deps.append(id)
+                        self.logger.debug(
+                            f"CPU Node ID {current_node.id} now has an inter-thread data dependency on Node ID {id}"
+                        )
 
                 if last_visited_non_gpu:
                     if last_visited_non_gpu.id not in current_node.data_deps:

--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -168,7 +168,9 @@ class PyTorch2ChakraConverter:
         self.pytorch_finish_ts = pytorch_et_data["finish_ts"]
 
         pytorch_nodes = pytorch_et_data["nodes"]
-        pytorch_node_objects = {node_data["id"]: PyTorchNode(node_data) for node_data in pytorch_nodes}
+        pytorch_node_objects = {
+            node_data["id"]: PyTorchNode(self.pytorch_schema, node_data) for node_data in pytorch_nodes
+        }
         self._establish_parent_child_relationships(pytorch_node_objects)
 
     def _establish_parent_child_relationships(self, pytorch_node_objects: Dict[int, PyTorchNode]) -> None:
@@ -263,13 +265,13 @@ class PyTorch2ChakraConverter:
         chakra_node.type = self.get_chakra_node_type_from_pytorch_node(pytorch_node)
         if pytorch_node.parent in self.chakra_nodes:
             chakra_node.ctrl_deps.append(pytorch_node.parent)
-        chakra_node.duration_micros = pytorch_node.exclusive_dur
-        chakra_node.inputs.values = str(pytorch_node.inputs)
-        chakra_node.inputs.shapes = str(pytorch_node.input_shapes)
-        chakra_node.inputs.types = str(pytorch_node.input_types)
-        chakra_node.outputs.values = str(pytorch_node.outputs)
-        chakra_node.outputs.shapes = str(pytorch_node.output_shapes)
-        chakra_node.outputs.types = str(pytorch_node.output_types)
+        chakra_node.duration_micros = int(pytorch_node.exclusive_dur)
+        chakra_node.inputs.values = str(pytorch_node.inputs["values"])
+        chakra_node.inputs.shapes = str(pytorch_node.inputs["shapes"])
+        chakra_node.inputs.types = str(pytorch_node.inputs["types"])
+        chakra_node.outputs.values = str(pytorch_node.outputs["values"])
+        chakra_node.outputs.shapes = str(pytorch_node.outputs["shapes"])
+        chakra_node.outputs.types = str(pytorch_node.outputs["types"])
         chakra_node.attr.extend(
             [
                 ChakraAttr(name="rf_id", int64_val=pytorch_node.rf_id),
@@ -280,7 +282,6 @@ class PyTorch2ChakraConverter:
                 ChakraAttr(name="fw_tid", int64_val=pytorch_node.fw_tid),
                 ChakraAttr(name="op_schema", string_val=pytorch_node.op_schema),
                 ChakraAttr(name="is_cpu_op", int32_val=not pytorch_node.is_gpu_op()),
-                ChakraAttr(name="ts", int64_val=pytorch_node.ts),
             ]
         )
         return chakra_node

--- a/et_converter/pytorch2chakra_converter.py
+++ b/et_converter/pytorch2chakra_converter.py
@@ -406,7 +406,6 @@ class PyTorch2ChakraConverter:
         stack: List[ChakraNode] = [chakra_node]
         last_visited_non_gpu: Optional[ChakraNode] = None
         last_visited_any: Optional[ChakraNode] = None
-        last_gpu_in_stream: Dict[int, ChakraNode] = {}
 
         while stack:
             current_node = stack.pop()
@@ -431,16 +430,7 @@ class PyTorch2ChakraConverter:
                             f"dependency on Node ID {last_visited_any.id}"
                         )
 
-                stream_id = pytorch_node.stream
-                if stream_id in last_gpu_in_stream:
-                    if last_gpu_in_stream[stream_id].id not in current_node.data_deps:
-                        current_node.data_deps.append(last_gpu_in_stream[stream_id].id)
-                        self.logger.debug(
-                            f"GPU Node ID {current_node.id} in stream {stream_id} now has a data "
-                            f"dependency on GPU Node ID {last_gpu_in_stream[stream_id].id} in the same stream."
-                        )
-                last_gpu_in_stream[stream_id] = current_node
-                last_visited_any = current_node
+                last_visited_any = last_visited_non_gpu
             else:
                 if pytorch_node.inter_thread_dep:
                     id = pytorch_node.inter_thread_dep

--- a/et_converter/pytorch_node.py
+++ b/et_converter/pytorch_node.py
@@ -3,6 +3,8 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from .pytorch_tensor import PyTorchTensor
+
 
 class PyTorchNodeType(Enum):
     CPU_OP = 1
@@ -185,13 +187,12 @@ class PyTorchNode:
         Returns:
             int: The calculated communication size.
         """
-        comm_size = 1
-        for input_type, input_shape in zip(self.inputs["types"], self.inputs["shapes"]):
-            type_size = self.get_data_type_size(input_type)
-            shape_size = 1
-            for dim in input_shape:
-                shape_size *= dim
-            comm_size += type_size * shape_size
+        comm_size = 0
+        for input_value, input_type in zip(self.inputs["values"], self.inputs["types"]):
+            if "Tensor" in input_type:
+                tensor = PyTorchTensor(input_value)
+                input_size = tensor.num_elem * tensor.elem_bytes
+                comm_size += input_size
         return comm_size
 
     @staticmethod

--- a/et_converter/pytorch_node.py
+++ b/et_converter/pytorch_node.py
@@ -12,34 +12,46 @@ class PyTorchNodeType(Enum):
 
 class PyTorchNode:
     """
-    Represents a node in a PyTorch execution trace.
+    Represents a node in a PyTorch execution trace, initialized based on a
+    schema version.
 
     Attributes:
-        node_data (Dict[str, Any]): Data of the PyTorch node.
+        schema (str): Schema version used for initialization.
         data_deps (List[PyTorchNode]): List of data-dependent parent nodes.
         children (List[PyTorchNode]): List of child nodes.
+        gpu_children (List[PyTorchNode]): List of GPU-specific child nodes.
+        record_param_comms_node (Optional['PyTorchNode']): Corresponding record_param_comms node.
+        nccl_node (Optional['PyTorchNode']): Corresponding NCCL node.
+        id (int): Unique identifier of the node.
+        name (str): Name of the node.
+        parent (int): Control dependencies identifier.
+        inputs (Dict[str, Any]): Input data including values, shapes, and types.
+        outputs (Dict[str, Any]): Output data including values, shapes, and types.
     """
 
-    def __init__(self, node_data: Dict[str, Any]) -> None:
+    def __init__(self, schema: str, node_data: Dict[str, Any]) -> None:
         """
-        Initializes a PyTorchNode object with the provided node data.
+        Initializes a PyTorchNode object using the node data and schema version provided.
 
         Args:
-            node_data (Dict[str, Any]): Dictionary containing the data of the
-            PyTorch node.
+            schema (str): The schema version based on which the node will be initialized.
+            node_data (Dict[str, Any]): Dictionary containing the data of the PyTorch node.
         """
-        self.node_data = node_data
+        self.schema = schema
         self.data_deps: List["PyTorchNode"] = []
         self.children: List["PyTorchNode"] = []
         self.gpu_children: List["PyTorchNode"] = []
         self.record_param_comms_node: Optional["PyTorchNode"] = None
         self.nccl_node: Optional["PyTorchNode"] = None
 
+        self.parse_data(node_data)
+
     def __repr__(self) -> str:
         """
-        Represent the PyTorchNode as a string.
+        Provides a string representation of the PyTorchNode.
+
         Returns:
-            str: A detailed string representation of the PyTorchNode.
+            str: String representation of the node.
         """
         return (
             f"PyTorchNode("
@@ -50,450 +62,43 @@ class PyTorchNode:
             f"exclusive_duration={self.exclusive_dur})"
         )
 
-    @property
-    def name(self) -> str:
+    def parse_data(self, node_data: Dict[str, Any]) -> None:
         """
-        Returns the name of the node.
-
-        Returns:
-            str: Name of the node.
-        """
-        return self.node_data["name"]
-
-    @name.setter
-    def name(self, value: str) -> None:
-        """
-        Sets the name of the node.
+        Parses node data based on the provided schema version.
 
         Args:
-            value (str): The new name of the node.
-        """
-        self.node_data["name"] = value
-
-    @property
-    def id(self) -> int:
-        """
-        Returns the node ID.
-
-        Returns:
-            int: ID of the node.
-        """
-        return self.node_data["id"]
-
-    @id.setter
-    def id(self, value: int) -> None:
-        """
-        Sets the node ID.
-
-        Args:
-            value (int): The new ID of the node.
-        """
-        self.node_data["id"] = value
-
-    @property
-    def rf_id(self) -> int:
-        """
-        Returns the unique record function ID.
-
-        Returns:
-            int: The unique record function ID.
-        """
-        return self.node_data["rf_id"]
-
-    @rf_id.setter
-    def rf_id(self, value: int) -> None:
-        """
-        Sets the unique record function ID.
-
-        Args:
-            value (int): The new unique record function ID.
-        """
-        self.node_data["rf_id"] = value
-
-    @property
-    def parent(self) -> int:
-        """
-        Returns the parent node ID.
-
-        Returns:
-            int: The parent node ID.
-        """
-        return self.node_data["parent"]
-
-    @parent.setter
-    def parent(self, value: int) -> None:
-        """
-        Sets the parent node ID.
-
-        Args:
-            value (int): The new parent node ID.
-        """
-        self.node_data["parent"] = value
-
-    @property
-    def fw_parent(self) -> int:
-        """
-        Returns the parent node ID from the forward thread.
-
-        Returns:
-            int: The parent node ID from the forward thread.
-        """
-        return self.node_data["fw_parent"]
-
-    @fw_parent.setter
-    def fw_parent(self, value: int) -> None:
-        """
-        Sets the parent node ID from the forward thread.
-
-        Args:
-            value (int): The new parent node ID from the forward thread.
-        """
-        self.node_data["fw_parent"] = value
-
-    @property
-    def seq_id(self) -> int:
-        """
-        Returns the record function sequence ID used to correlate forward and
-        backward operators.
-
-        Returns:
-            int: The record function sequence ID.
-        """
-        return self.node_data["seq_id"]
-
-    @seq_id.setter
-    def seq_id(self, value: int) -> None:
-        """
-        Sets the record function sequence ID.
-
-        Args:
-            value (int): The new sequence ID.
-        """
-        self.node_data["seq_id"] = value
-
-    @property
-    def scope(self) -> int:
-        """
-        Returns the record scope.
-
-        Returns:
-            int: The record scope.
-        """
-        return self.node_data["scope"]
-
-    @scope.setter
-    def scope(self, value: int) -> None:
-        """
-        Sets the record scope.
-
-        Args:
-            value (int): The new scope value.
-        """
-        self.node_data["scope"] = value
-
-    @property
-    def tid(self) -> int:
-        """
-        Returns the record function thread ID.
-
-        Returns:
-            int: The record function thread ID.
-        """
-        return self.node_data["tid"]
-
-    @tid.setter
-    def tid(self, value: int) -> None:
-        """
-        Sets the record function thread ID.
-
-        Args:
-            value (int): The new thread ID.
-        """
-        self.node_data["tid"] = value
-
-    @property
-    def fw_tid(self) -> int:
-        """
-        Returns the thread ID of the forward execution thread.
-
-        Returns:
-            int: The thread ID of the forward execution thread.
-        """
-        return self.node_data["fw_tid"]
-
-    @fw_tid.setter
-    def fw_tid(self, value: int) -> None:
-        """
-        Sets the thread ID of the forward execution thread.
-
-        Args:
-            value (int): The new forward thread ID.
-        """
-        self.node_data["fw_tid"] = value
-
-    @property
-    def op_schema(self) -> str:
-        """
-        Returns the PyTorch operator schema.
-
-        Returns:
-            str: The PyTorch operator schema.
-        """
-        return self.node_data["op_schema"]
-
-    @op_schema.setter
-    def op_schema(self, value: str) -> None:
-        """
-        Sets the PyTorch operator schema.
-
-        Args:
-            value (str): The new operator schema.
-        """
-        self.node_data["op_schema"] = value
-
-    @property
-    def inputs(self) -> List[Any]:
-        """
-        Returns the array of input arguments.
-
-        Returns:
-            List[Any]: The array of input arguments.
-        """
-        return self.node_data["inputs"]
-
-    @inputs.setter
-    def inputs(self, value: List[Any]) -> None:
-        """
-        Sets the array of input arguments.
-
-        Args:
-            value (List[Any]): The new array of input arguments.
-        """
-        self.node_data["inputs"] = value
-
-    @property
-    def input_shapes(self) -> List[Any]:
-        """
-        Returns the array of input shapes.
-
-        Returns:
-            List[Any]: The array of input shapes.
-        """
-        return self.node_data["input_shapes"]
-
-    @input_shapes.setter
-    def input_shapes(self, value: List[Any]) -> None:
-        """
-        Sets the array of input shapes.
-
-        Args:
-            value (List[Any]): The new array of input shapes.
-        """
-        self.node_data["input_shapes"] = value
-
-    @property
-    def input_types(self) -> List[Any]:
-        """
-        Returns the array of input types.
-
-        Returns:
-            List[Any]: The array of input types.
-        """
-        return self.node_data["input_types"]
-
-    @input_types.setter
-    def input_types(self, value: List[Any]) -> None:
-        """
-        Sets the array of input types.
-
-        Args:
-            value (List[Any]): The new array of input types.
-        """
-        self.node_data["input_types"] = value
-
-    @property
-    def outputs(self) -> List[Any]:
-        """
-        Returns the array of output arguments.
-
-        Returns:
-            List[Any]: The array of output arguments.
-        """
-        return self.node_data["outputs"]
-
-    @outputs.setter
-    def outputs(self, value: List[Any]) -> None:
-        """
-        Sets the array of output arguments.
-
-        Args:
-            value (List[Any]): The new array of output arguments.
-        """
-        self.node_data["outputs"] = value
-
-    @property
-    def output_shapes(self) -> List[Any]:
-        """
-        Returns the array of output shapes.
-
-        Returns:
-            List[Any]: The array of output shapes.
-        """
-        return self.node_data["output_shapes"]
-
-    @output_shapes.setter
-    def output_shapes(self, value: List[Any]) -> None:
-        """
-        Sets the array of output shapes.
-
-        Args:
-            value (List[Any]): The new array of output shapes.
-        """
-        self.node_data["output_shapes"] = value
-
-    @property
-    def output_types(self) -> List[Any]:
-        """
-        Returns the array of output types.
-
-        Returns:
-            List[Any]: The array of output types.
-        """
-        return self.node_data["output_types"]
-
-    @output_types.setter
-    def output_types(self, value: List[Any]) -> None:
-        """
-        Sets the array of output types.
-
-        Args:
-            value (List[Any]): The new array of output types.
-        """
-        self.node_data["output_types"] = value
-
-    @property
-    def ts(self) -> int:
-        """
-        Returns the timestamp of the node.
-
-        Returns:
-            int: The timestamp of the node.
-        """
-        return self.node_data.get("ts", 0)
-
-    @ts.setter
-    def ts(self, value: int) -> None:
-        """
-        Sets the timestamp of the node.
-
-        Args:
-            value (int): The new timestamp of the node.
-        """
-        self.node_data["ts"] = value
-
-    @property
-    def cat(self) -> str:
-        """
-        Returns the category field of the node.
-
-        Returns:
-            str: The category field of the node.
-        """
-        return self.node_data.get("cat", "")
-
-    @cat.setter
-    def cat(self, value: str) -> None:
-        """
-        Sets the category field of the node.
-
-        Args:
-            value (str): The new category field of the node.
-        """
-        self.node_data["cat"] = value
-
-    @property
-    def inclusive_dur(self) -> int:
-        """
-        Returns the inclusive duration of the node.
-
-        Returns:
-            int: The inclusive duration of the node.
-        """
-        if "inclusive_dur" in self.node_data:
-            return self.node_data["inclusive_dur"]
-        return 0
-
-    @inclusive_dur.setter
-    def inclusive_dur(self, value: int) -> None:
-        """
-        Sets the inclusive duration of the node.
-
-        Args:
-            value (int): The new inclusive duration of the node.
-        """
-        self.node_data["inclusive_dur"] = value
-
-    @property
-    def exclusive_dur(self) -> int:
-        """
-        Returns the exclusive duration of the node.
-
-        Returns:
-            int: The exclusive duration of the node.
-        """
-        return self.node_data.get("exclusive_dur", 0)
-
-    @exclusive_dur.setter
-    def exclusive_dur(self, value: int) -> None:
-        """
-        Sets the exclusive duration of the node.
-
-        Args:
-            value (int): The new exclusive duration of the node.
-        """
-        self.node_data["exclusive_dur"] = value
-
-    @property
-    def inter_thread_dep(self) -> Optional[int]:
-        """
-        Returns the inter-thread dependency value of the node, if available.
-
-        Returns:
-            Optional[int]: The inter-thread dependency value or None if not
-                           available.
-        """
-        return self.node_data.get("inter_thread_dep")
-
-    @property
-    def stream(self) -> int:
-        return self.node_data["stream"]
-
-    def has_ts(self) -> bool:
-        """
-        Checks if the node has a timestamp field.
-
-        Returns:
-            bool: True if the node has a timestamp field, False otherwise.
-        """
-        return "ts" in self.node_data
-
-    def has_cat(self) -> bool:
-        """
-        Checks if the node has a category field.
-
-        Returns:
-            bool: True if the node has a category field, False otherwise.
-        """
-        return "cat" in self.node_data
-
-    def has_dur(self) -> bool:
-        """
-        Checks if the node has a duration field.
-
-        Returns:
-            bool: True if the node has a duration field, False otherwise.
-        """
-        return "inclusive_dur" in self.node_data
+            node_data (Dict[str, Any]): The node data to be parsed.
+        """
+        supported_versions = ["1.0.2-chakra.0.0.4", "1.0.3-chakra.0.0.4"]
+        if self.schema in supported_versions:
+            if self.schema == "1.0.2-chakra.0.0.4":
+                self._parse_data_1_0_3_chakra_0_0_4(node_data)
+            elif self.schema == "1.0.3-chakra.0.0.4":
+                self._parse_data_1_0_3_chakra_0_0_4(node_data)
+        else:
+            raise ValueError(
+                f"Unsupported schema version '{self.schema}'. Please check "
+                f"if the schema version is in the list of supported versions: "
+                f"{supported_versions}"
+            )
+
+    def _parse_data_1_0_3_chakra_0_0_4(self, node_data: Dict[str, Any]) -> None:
+        self.id = node_data["id"]
+        self.name = node_data["name"]
+        self.parent = node_data["ctrl_deps"]
+        self.inputs = node_data["inputs"]
+        self.outputs = node_data["outputs"]
+
+        # TODO: should be added as attributes
+        self.inclusive_dur = node_data.get("inclusive_dur")
+        self.exclusive_dur = node_data.get("exclusive_dur", 0)
+        self.ts = node_data.get("ts")
+        self.inter_thread_dep = node_data.get("inter_thread_dep")
+        self.cat = node_data.get("cat", None)
+        self.stream = node_data.get("stream", None)
+
+        for attr in node_data.get("attrs", []):
+            setattr(self, attr["name"], attr["value"])
 
     def get_op_type(self) -> PyTorchNodeType:
         """
@@ -504,7 +109,7 @@ class PyTorchNode:
         """
         if self.is_gpu_op():
             return PyTorchNodeType.GPU_OP
-        elif self.node_data.get("op_schema") or self.node_data.get("outputs"):
+        elif hasattr(self, "op_schema") or hasattr(self, "outputs"):
             return PyTorchNodeType.CPU_OP
         else:
             return PyTorchNodeType.LABEL
@@ -525,7 +130,7 @@ class PyTorchNode:
         Returns:
             bool: True if the node is a GPU operator, False otherwise.
         """
-        return self.has_cat()
+        return self.cat is not None
 
     def add_data_dep(self, parent_node: "PyTorchNode") -> None:
         """
@@ -581,7 +186,7 @@ class PyTorchNode:
             int: The calculated communication size.
         """
         comm_size = 1
-        for input_type, input_shape in zip(self.input_types, self.input_shapes):
+        for input_type, input_shape in zip(self.inputs["types"], self.inputs["shapes"]):
             type_size = self.get_data_type_size(input_type)
             shape_size = 1
             for dim in input_shape:


### PR DESCRIPTION
## Summary
Fix bugs in et_converter
* Fix formatting due to ruff in et_converter/pytorch2chakra_converter.py
* Remove UniqueIdAssigner from et_converter/pytorch2chakra_converter.py
* Update pytorch2chakra_converter to support various versions
* Ignore et_converter/ for pyre checks
* Use GPU operator's name for identifying communication type
* Fix communication size calculation logic
* Remove inter-stream dependencies

## Test Plan
**1. Run trace_link**
```
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_0.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_0.json --output-file ~/megatron_0.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_1.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_1.json --output-file ~/megatron_1.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_2.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_2.json --output-file ~/megatron_2.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_3.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_3.json --output-file ~/megatron_3.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_4.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_4.json --output-file ~/megatron_4.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_5.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_5.json --output-file ~/megatron_5.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_6.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_6.json --output-file ~/megatron_6.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_7.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_7.json --output-file ~/megatron_7.json &
```

**2. Run et_converter**
```
chakra_converter --input_filename ~/megatron_0.json --output_filename megatron_0.chakra --input_type PyTorch > /tmp/rank_0 &
chakra_converter --input_filename ~/megatron_1.json --output_filename megatron_1.chakra --input_type PyTorch > /tmp/rank_1 &
chakra_converter --input_filename ~/megatron_2.json --output_filename megatron_2.chakra --input_type PyTorch > /tmp/rank_2 &
chakra_converter --input_filename ~/megatron_3.json --output_filename megatron_3.chakra --input_type PyTorch > /tmp/rank_3 &
chakra_converter --input_filename ~/megatron_4.json --output_filename megatron_4.chakra --input_type PyTorch > /tmp/rank_4 &
chakra_converter --input_filename ~/megatron_5.json --output_filename megatron_5.chakra --input_type PyTorch > /tmp/rank_5 &
chakra_converter --input_filename ~/megatron_6.json --output_filename megatron_6.chakra --input_type PyTorch > /tmp/rank_6 &
chakra_converter --input_filename ~/megatron_7.json --output_filename megatron_7.chakra --input_type PyTorch > /tmp/rank_7 &
```

**3. Results**
![Screenshot 2024-05-08 at 7 42 27 PM](https://github.com/mlcommons/chakra/assets/7621438/40cdeb48-d374-4ebf-a72d-34dd9d55e478)