### PR TITLE
Enable Pyright for Type Checking

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -23,3 +23,7 @@ jobs:
       run: |
         ruff format .
         ruff check .
+
+    - name: Run Pyright
+      run: |
+        pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,14 @@ select = ["I", "B", "E", "F", "SIM", "W", "C90"]
 
 [tool.ruff.format]
 indent-style = "space"
+
+[tool.pyright]
+typeCheckingMode = "basic"
+exclude = [
+    "**/__pycache__",
+    "**/build/",
+    "setup.py",
+    "src/third_party/utils/protolib.py"
+]
+reportMissingImports = false
+reportAttributeAccessIssue = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pyre-check==0.9.19
+pyright==1.1.359
 ruff==0.3.5

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -81,7 +81,7 @@ class PyTorchConverter:
         self.pytorch_time = None
         self.pytorch_start_ts = None
         self.pytorch_finish_ts = None
-        self.pytorch_nodes = None
+        self.pytorch_nodes = dict()
         self.pytorch_root_nids = []
 
         # Initialize node mapping dictionaries


### PR DESCRIPTION
## Summary
Enable Pyright for type checking

## Test Plan
**1. CI/CD pipelines are passing
2. Correlation**

**2.1 Run trace_link**
```
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_0.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_0.json --output-file ~/megatron_0.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_1.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_1.json --output-file ~/megatron_1.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_2.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_2.json --output-file ~/megatron_2.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_3.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_3.json --output-file ~/megatron_3.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_4.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_4.json --output-file ~/megatron_4.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_5.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_5.json --output-file ~/megatron_5.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_6.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_6.json --output-file ~/megatron_6.json &
chakra_trace_link --pytorch-et-file /Users/theo/Downloads/llama_pytorch24.05/megatron_et_7.json --kineto-file /Users/theo/Downloads/llama_pytorch24.05/megatron_kineto_7.json --output-file ~/megatron_7.json &
```

**2.2 Run et_converter**
```
chakra_converter --input_filename ~/megatron_0.json --output_filename megatron_0.chakra --input_type PyTorch > /tmp/rank_0 &
chakra_converter --input_filename ~/megatron_1.json --output_filename megatron_1.chakra --input_type PyTorch > /tmp/rank_1 &
chakra_converter --input_filename ~/megatron_2.json --output_filename megatron_2.chakra --input_type PyTorch > /tmp/rank_2 &
chakra_converter --input_filename ~/megatron_3.json --output_filename megatron_3.chakra --input_type PyTorch > /tmp/rank_3 &
chakra_converter --input_filename ~/megatron_4.json --output_filename megatron_4.chakra --input_type PyTorch > /tmp/rank_4 &
chakra_converter --input_filename ~/megatron_5.json --output_filename megatron_5.chakra --input_type PyTorch > /tmp/rank_5 &
chakra_converter --input_filename ~/megatron_6.json --output_filename megatron_6.chakra --input_type PyTorch > /tmp/rank_6 &
chakra_converter --input_filename ~/megatron_7.json --output_filename megatron_7.chakra --input_type PyTorch > /tmp/rank_7 &
```

**2.3 Results**
![Screenshot 2024-05-08 at 7 42 27 PM](https://github.com/mlcommons/chakra/assets/7621438/40cdeb48-d374-4ebf-a72d-34dd9d55e478)