### PR TITLE
Support GPU-to-CPU synchronization dependency with HolisticTraceAnalysis

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -26,6 +26,15 @@ jobs:
         git checkout 7b19f586dd8b267333114992833a0d7e0d601630
         pip install .
 
+    - name: Install HTA
+      run: |
+        git clone https://github.com/facebookresearch/HolisticTraceAnalysis.git
+        cd HolisticTraceAnalysis
+        git checkout d731cc2e2249976c97129d409a83bd53d93051f6
+        git submodule update --init
+        pip install -r requirements.txt
+        pip install -e .
+
     - name: Test chakra_trace_link Without Arguments
       run: |
         chakra_trace_link || [ $? -eq 2 ]

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -26,6 +26,15 @@ jobs:
         git checkout 7b19f586dd8b267333114992833a0d7e0d601630
         pip install .
 
+    - name: Install HTA
+      run: |
+        git clone https://github.com/facebookresearch/HolisticTraceAnalysis.git
+        cd HolisticTraceAnalysis
+        git checkout d731cc2e2249976c97129d409a83bd53d93051f6
+        git submodule update --init
+        pip install -r requirements.txt
+        pip install -e .
+
     - name: Install Dependencies
       run: |
         pip install -r requirements-dev.txt

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -35,7 +35,19 @@ $ git checkout 7b19f586dd8b267333114992833a0d7e0d601630
 $ pip install .
 ```
 
-### Step 4: Uninstalling Chakra
+### Step 4: Install Holistic Trace Analysis
+Installing Holistic Trace Analysis is necessary for Trace link.
+
+```bash
+$ git clone https://github.com/facebookresearch/HolisticTraceAnalysis.git
+$ cd HolisticTraceAnalysis
+$ git checkout d731cc2e2249976c97129d409a83bd53d93051f6
+$ git submodule update --init
+$ pip install -r requirements.txt
+$ pip install -e .
+```
+
+### Step 5: Uninstalling Chakra
 To uninstall Chakra, use the following command within the virtual environment.
 
 ```bash
@@ -49,6 +61,7 @@ Merge Chakra host execution trace and Chakra device execution trace to encode GP
 $ chakra_trace_link \
     --chakra-host-trace /path/to/chakra_host_trace \
     --chakra-device-trace /path/to/chakra_device_trace \
+    --rank [RANK] \
     --output-file /path/to/chakra_host_device_trace.json
 ```
 

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -244,7 +244,11 @@ class PyTorchConverter:
                             [
                                 ChakraAttr(name="comm_type", int64_val=collective_comm_type),
                                 ChakraAttr(name="comm_size", int64_val=pytorch_gpu_node.comm_size),
-                                *( [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)] if pytorch_gpu_node.pg_name != "" else [] ),
+                                *(
+                                    [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)]
+                                    if pytorch_gpu_node.pg_name != ""
+                                    else []
+                                ),
                             ]
                         )
 
@@ -252,7 +256,11 @@ class PyTorchConverter:
                         chakra_gpu_node.attr.extend(
                             [
                                 ChakraAttr(name="comm_size", int64_val=pytorch_gpu_node.comm_size),
-                                *( [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)] if pytorch_gpu_node.pg_name != "" else [] ),
+                                *(
+                                    [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)]
+                                    if pytorch_gpu_node.pg_name != ""
+                                    else []
+                                ),
                             ]
                         )
 

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -457,6 +457,15 @@ class PyTorchConverter:
                 last_visited_non_gpu = current_node
                 last_visited_any = current_node
 
+            if json_node.sync_dep:
+                for sync_dep in json_node.sync_dep:
+                    if sync_dep not in current_node.data_deps:
+                        current_node.data_deps.append(sync_dep)
+                        logging.info(
+                            f"Node ID {current_node.id} now has an synchonization dependency on Node ID {sync_dep}"
+                        )
+
+            # Add children to the stack
             children_chakra_ids = [child.id for child in json_node.children]
             for child_chakra_id in sorted(children_chakra_ids, reverse=True):
                 child_chakra_node = protobuf_node_map.get(child_chakra_id)

--- a/src/converter/pytorch_node.py
+++ b/src/converter/pytorch_node.py
@@ -19,7 +19,7 @@ class PyTorchNodeType(Enum):
     CPU_OP = 1
     GPU_OP = 2
     LABEL = 3  # Non-operator nodes
-    METADATA = 4 # Metadata nodes
+    METADATA = 4  # Metadata nodes
 
 
 class PyTorchNode:

--- a/src/converter/pytorch_node.py
+++ b/src/converter/pytorch_node.py
@@ -110,6 +110,7 @@ class PyTorchNode:
         self.exclusive_dur = node_data.get("exclusive_dur", 0)
         self.ts = node_data.get("ts")
         self.inter_thread_dep = node_data.get("inter_thread_dep")
+        self.sync_dep = node_data.get("sync_dep")
         self.cat = node_data.get("cat")
         self.stream = node_data.get("stream", 0)
         # In Colletive comms nodes, pg_name is in node_data if exists.

--- a/src/trace_link/chakra_device_trace_loader.py
+++ b/src/trace_link/chakra_device_trace_loader.py
@@ -16,6 +16,7 @@ class ChakraDeviceTraceLoader:
     ) -> Tuple[
         List[KinetoOperator],
         Dict[int, List[KinetoOperator]],
+        Dict[int, List[KinetoOperator]],
         Dict[int, KinetoOperator],
         List[KinetoOperator],
         Dict[int, KinetoOperator],
@@ -26,6 +27,7 @@ class ChakraDeviceTraceLoader:
         Dict[int, KinetoOperator],
         List[KinetoOperator],
         List[int],
+        Dict[int, KinetoOperator],
     ]:
         """
         Load and process the Chakra device trace.
@@ -57,6 +59,7 @@ class ChakraDeviceTraceLoader:
         logging.debug("Chakra device trace has been loaded and processed successfully.")
         return (
             dev_data["kineto_cpu_ops"],
+            dev_data["kineto_tid_ops_map"],
             dev_data["kineto_tid_cpu_ops_map"],
             dev_data["kineto_correlation_cuda_runtime_map"],
             dev_data["kineto_gpu_ops"],
@@ -68,6 +71,7 @@ class ChakraDeviceTraceLoader:
             dev_data["kineto_rf_id_to_kineto_op_map"],
             dev_data["sorted_kineto_cpu_ops"],
             dev_data["sorted_kineto_cpu_op_ts"],
+            dev_data["kineto_external_id_to_kineto_op_map"],
         )
 
     def construct_dev_data_structures(self, kineto_ops: List[KinetoOperator], trace_file: str) -> Dict:
@@ -90,13 +94,17 @@ class ChakraDeviceTraceLoader:
         thread_info = {}
 
         kineto_cpu_ops = []
+        kineto_tid_ops_map = {}
         kineto_tid_cpu_ops_map = {}
         kineto_correlation_cuda_runtime_map = {}
         kineto_gpu_ops = []
         kineto_id_arrow_op_map = {}
         kineto_id_cuda_launch_op_map = {}
+        kineto_external_id_to_kineto_op_map = {}
 
         for op in kineto_ops:
+            kineto_tid_ops_map.setdefault(op.tid, []).append(op)
+
             if op.is_cpu_op():
                 kineto_cpu_ops.append(op)
                 kineto_tid_cpu_ops_map.setdefault(op.tid, []).append(op)
@@ -144,10 +152,14 @@ class ChakraDeviceTraceLoader:
                 thread_start_end[0] = min(thread_start_end[0], op.timestamp)
                 thread_start_end[1] = max(thread_start_end[1], op.timestamp + op.inclusive_dur)
 
+            if op.external_id is not None:
+                kineto_external_id_to_kineto_op_map[op.external_id] = op
+
         kineto_rf_id_to_kineto_op_map = {op.rf_id: op for op in kineto_cpu_ops if op.rf_id is not None}
 
         return {
             "kineto_cpu_ops": kineto_cpu_ops,
+            "kineto_tid_ops_map": kineto_tid_ops_map,
             "kineto_tid_cpu_ops_map": kineto_tid_cpu_ops_map,
             "kineto_correlation_cuda_runtime_map": kineto_correlation_cuda_runtime_map,
             "kineto_gpu_ops": kineto_gpu_ops,
@@ -159,6 +171,7 @@ class ChakraDeviceTraceLoader:
             "kineto_rf_id_to_kineto_op_map": kineto_rf_id_to_kineto_op_map,
             "sorted_kineto_cpu_ops": [],
             "sorted_kineto_cpu_op_ts": [],
+            "kineto_external_id_to_kineto_op_map": kineto_external_id_to_kineto_op_map,
         }
 
     def calculate_exclusive_dur(self, kineto_tid_cpu_ops_map: Dict[int, List[KinetoOperator]]) -> None:

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from et_replay.execution_trace import Node as PyTorchOperator
 
@@ -22,6 +22,7 @@ class KinetoOperator:
         host_op (Optional[PyTorchOperator]): Corresponding PyTorch operator object.
         parent_host_op_id (Optional[int]): ID of the parent PyTorch operator.
         inter_thread_dep (Optional[int]): Identifier for inter-thread dependencies.
+        sync_dep (List[KinetoOperator]): List of KinetoOperator objects that have dependencies on this operator.
         stream (Optional[int]): CUDA stream identifier associated with the operator.
         rf_id (Optional[int]): Record function identifier.
         correlation (int): Identifier used to correlate CUDA runtime and GPU operations.
@@ -49,6 +50,7 @@ class KinetoOperator:
         self.host_op: Optional[PyTorchOperator] = None
         self.parent_host_op_id: Optional[int] = None
         self.inter_thread_dep: Optional[int] = None
+        self.sync_dep: List[KinetoOperator] = []
         self.stream: Optional[int] = kineto_op.get("args", {}).get("stream", None)
         self.rf_id: Optional[int] = kineto_op.get("args", {}).get("Record function id", None)
         self.correlation: int = kineto_op.get("args", {}).get("correlation", -1)
@@ -61,13 +63,14 @@ class KinetoOperator:
         Returns
             str: A string representation of the KinetoOperator.
         """
+        sync_dep_ids = [op.id for op in self.sync_dep]
         return (
             f"KinetoOperator(id={self.id}, category={self.category}, name={self.name}, "
             f"phase={self.phase}, inclusive_dur={self.inclusive_dur}, "
             f"exclusive_dur={self.exclusive_dur}, timestamp={self.timestamp}, "
             f"external_id={self.external_id}, ev_idx={self.ev_idx}, tid={self.tid}, "
             f"parent_host_op_id={self.parent_host_op_id}, inter_thread_dep={self.inter_thread_dep}, "
-            f"stream={self.stream}, rf_id={self.rf_id}, correlation={self.correlation})"
+            f"sync_dep={sync_dep_ids}, stream={self.stream}, rf_id={self.rf_id}, correlation={self.correlation})"
         )
 
     def is_cpu_op(self) -> bool:

--- a/src/trace_link/trace_link.py
+++ b/src/trace_link/trace_link.py
@@ -18,6 +18,7 @@ def main() -> None:
             "Merging-PyTorch-and-Kineto-Traces"
         )
     )
+    parser.add_argument("--rank", type=int, required=True, help="Rank for the input traces")
     parser.add_argument(
         "--chakra-host-trace",
         type=str,
@@ -43,10 +44,11 @@ def main() -> None:
     logging.basicConfig(level=args.log_level.upper())
 
     linker = TraceLinker()
-    linker.link(args.chakra_host_trace, args.chakra_device_trace, args.output_file)
+    linker.link(args.rank, args.chakra_host_trace, args.chakra_device_trace, args.output_file)
 
     logging.info(f"Linking process successful. Output file is available at {args.output_file}.")
     logging.info("Please run the chakra_converter for further postprocessing.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -115,7 +115,9 @@ class TraceLinker:
                 that have synchronization dependencies.
         """
         sync_dependencies = {}
-        trace_analysis = TraceAnalysis(trace_dir=os.path.dirname(kineto_file))
+        absolute_kineto_file = os.path.abspath(kineto_file)
+        trace_dir = os.path.dirname(absolute_kineto_file)
+        trace_analysis = TraceAnalysis(trace_dir=trace_dir)
         cp_graph, success = trace_analysis.critical_path_analysis(
             rank=rank, annotation=annotation, instance_id=instance_id
         )

--- a/tests/trace_link/test_kineto_operator.py
+++ b/tests/trace_link/test_kineto_operator.py
@@ -43,7 +43,7 @@ def test_repr_method(sample_operator_data):
     expected_repr = (
         "KinetoOperator(id=None, category=Kernel, name=cudaLaunchKernel, phase=X, "
         "inclusive_dur=100, exclusive_dur=100, timestamp=1590000000, external_id=123, ev_idx=456, "
-        "tid=1234, parent_host_op_id=None, inter_thread_dep=None, stream=7, rf_id=12, "
+        "tid=1234, parent_host_op_id=None, inter_thread_dep=None, sync_dep=[], stream=7, rf_id=12, "
         "correlation=99)"
     )
     assert repr(operator) == expected_repr

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -9,6 +9,7 @@ from et_replay.execution_trace import (
     EXECUTION_TRACE_THREAD_ANNOTATION,
 )
 from et_replay.execution_trace import Node as PyTorchOperator
+from hta.analyzers.critical_path_analysis import CPEdgeType, CPGraph
 
 
 @pytest.fixture
@@ -38,6 +39,7 @@ def test_link_traces(mock_map_ops, mock_add_annotations, mock_construct_et_plus,
     kineto_thread_info = {1: (100, 200)}
     kineto_process_start_time = 50
     kineto_process_end_time = 300
+    kineto_external_id_to_kineto_op_map = {1: MagicMock(spec=KinetoOperator)}
 
     trace_linker.link_traces(
         "pytorch_et_file",
@@ -51,6 +53,7 @@ def test_link_traces(mock_map_ops, mock_add_annotations, mock_construct_et_plus,
         kineto_thread_info,
         kineto_process_start_time,
         kineto_process_end_time,
+        kineto_external_id_to_kineto_op_map,
     )
 
     mock_add_annotations.assert_called_once()
@@ -88,6 +91,189 @@ def test_enforce_inter_thread_order_exception(mock_process_thread, mock_future_r
 
     with pytest.raises(Exception, match="Test Exception"):
         trace_linker.enforce_inter_thread_order(kineto_tid_cpu_ops_map)
+
+
+@pytest.mark.parametrize(
+    "trace_events, critical_path_edges, expected_result",
+    [
+        (
+            {0: {"args": {"External id": 1}, "name": "event_0"}, 1: {"args": {"External id": 2}, "name": "event_1"}},
+            [(0, 1)],
+            {2: [1]},
+        ),
+        (
+            {
+                0: {"args": {"External id": 1}, "name": "event_0"},
+                1: {"args": {"External id": 2}, "name": "event_1"},
+                2: {"args": {"External id": 3}, "name": "event_2"},
+            },
+            [(0, 2), (1, 2)],
+            {3: [1, 2]},
+        ),
+        (
+            {
+                0: {"args": {"External id": 1}, "name": "event_0"},
+                1: {"args": {"External id": 2}, "name": "event_1"},
+                2: {"args": {}, "name": "event_2"},
+            },
+            [(0, 1), (1, 2)],
+            {2: [1]},
+        ),
+    ],
+)
+@patch("hta.trace_analysis.TraceAnalysis.critical_path_analysis")
+@patch("hta.trace_analysis.Trace")
+def test_load_sync_dependencies_success(
+    mock_trace, mock_critical_path_analysis, trace_linker, trace_events, critical_path_edges, expected_result
+):
+    # Mock the Trace instance and its methods
+    mock_trace_instance = mock_trace.return_value
+    mock_trace_instance.is_parsed = True
+    mock_trace_instance.get_raw_trace_for_one_rank.return_value = {"traceEvents": trace_events}
+    mock_cp_graph = MagicMock(spec=CPGraph)
+    mock_cp_graph.critical_path_edges_set = [MagicMock(type=CPEdgeType.SYNC_DEPENDENCY) for _ in critical_path_edges]
+    mock_cp_graph.get_events_for_edge.side_effect = critical_path_edges
+    mock_critical_path_analysis.return_value = (mock_cp_graph, True)
+
+    # Call the method
+    result = trace_linker.load_sync_dependencies(0, "kineto_file.json", "ProfilerStep", 0)
+
+    # Assert the expected result
+    assert result == expected_result
+
+
+@patch("hta.trace_analysis.TraceAnalysis.critical_path_analysis")
+@patch("hta.trace_analysis.Trace")
+def test_load_sync_dependencies_failure(mock_trace, mock_critical_path_analysis, trace_linker):
+    # Mock the Trace instance and its methods to return failure
+    mock_trace_instance = mock_trace.return_value
+    mock_trace_instance.is_parsed = True
+    mock_cp_graph = MagicMock(spec=CPGraph)
+    mock_cp_graph.critical_path_edges_set = []
+    mock_critical_path_analysis.return_value = (mock_cp_graph, False)
+
+    # Call the method
+    result = trace_linker.load_sync_dependencies(0, "kineto_file.json", "ProfilerStep", 0)
+
+    # Assert the expected result
+    assert result == {}
+
+
+@patch("hta.trace_analysis.TraceAnalysis.critical_path_analysis")
+@patch("hta.trace_analysis.Trace")
+def test_load_sync_dependencies_missing_external_id(mock_trace, mock_critical_path_analysis, trace_linker):
+    # Mock the Trace instance and its methods
+    mock_trace_instance = mock_trace.return_value
+    mock_trace_instance.is_parsed = True
+    mock_trace_instance.get_raw_trace_for_one_rank.return_value = {
+        "traceEvents": {0: {"args": {"External id": 1}}, 1: {"args": {}}}
+    }
+    mock_cp_graph = MagicMock(spec=CPGraph)
+    mock_cp_graph.critical_path_edges_set = [MagicMock(type=CPEdgeType.SYNC_DEPENDENCY)]
+    mock_cp_graph.get_events_for_edge.return_value = (0, 1)
+    mock_critical_path_analysis.return_value = (mock_cp_graph, True)
+
+    # Call the method
+    result = trace_linker.load_sync_dependencies(0, "kineto_file.json", "ProfilerStep", 0)
+
+    # Assert the expected result
+    assert result == {}
+
+
+@pytest.mark.parametrize(
+    "sync_deps, current_tid, ops_by_tid, expected_sync_deps",
+    [
+        (
+            {1: [10, 20], 2: [30, 40]},
+            1,
+            {
+                1: [KinetoOperator({"external_id": 1}), KinetoOperator({"external_id": 2})],
+                2: [KinetoOperator({"external_id": 3})],
+            },
+            {1: [10, 20], 2: [30, 40]},
+        ),
+        (
+            {1: [10], 2: [20, 30], 3: [40]},
+            2,
+            {
+                1: [KinetoOperator({"external_id": 1})],
+                2: [KinetoOperator({"external_id": 2}), KinetoOperator({"external_id": 3})],
+            },
+            {2: [20, 30], 3: [40]},
+        ),
+        (
+            {},
+            1,
+            {
+                1: [KinetoOperator({"external_id": 1}), KinetoOperator({"external_id": 2})],
+            },
+            {},
+        ),
+    ],
+)
+def test_process_thread_sync_dep(sync_deps, current_tid, ops_by_tid, expected_sync_deps, trace_linker):
+    trace_linker.process_thread_sync_dep({}, ops_by_tid, [], current_tid, ops_by_tid[current_tid], sync_deps)
+
+    for op in ops_by_tid.get(current_tid, []):
+        assert op.sync_dep == expected_sync_deps.get(op.external_id, [])
+
+
+@pytest.mark.parametrize(
+    "op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts, expected_result",
+    [
+        # Case 1: One operator after the given timestamp
+        (
+            MagicMock(spec=KinetoOperator, timestamp=100),
+            [MagicMock(spec=KinetoOperator, timestamp=50), MagicMock(spec=KinetoOperator, timestamp=150)],
+            [50, 150],
+            1,  # index of the expected result in sorted_kineto_cpu_ops
+        ),
+        # Case 2: Multiple operators after the given timestamp
+        (
+            MagicMock(spec=KinetoOperator, timestamp=100),
+            [
+                MagicMock(spec=KinetoOperator, timestamp=50),
+                MagicMock(spec=KinetoOperator, timestamp=150),
+                MagicMock(spec=KinetoOperator, timestamp=200),
+            ],
+            [50, 150, 200],
+            1,  # index of the expected result in sorted_kineto_cpu_ops
+        ),
+        # Case 3: No operators after the given timestamp
+        (
+            MagicMock(spec=KinetoOperator, timestamp=100),
+            [MagicMock(spec=KinetoOperator, timestamp=50), MagicMock(spec=KinetoOperator, timestamp=75)],
+            [50, 75],
+            None,  # No result expected
+        ),
+        # Case 4: Operator with exact timestamp
+        (
+            MagicMock(spec=KinetoOperator, timestamp=100),
+            [
+                MagicMock(spec=KinetoOperator, timestamp=50),
+                MagicMock(spec=KinetoOperator, timestamp=100),
+                MagicMock(spec=KinetoOperator, timestamp=150),
+            ],
+            [50, 100, 150],
+            2,  # index of the expected result in sorted_kineto_cpu_ops
+        ),
+        # Case 5: Empty list of operators
+        (
+            MagicMock(spec=KinetoOperator, timestamp=100),
+            [],
+            [],
+            None,  # No result expected
+        ),
+    ],
+)
+def test_find_closest_start_kineto_op(
+    op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts, expected_result, trace_linker
+):
+    result = trace_linker.find_closest_start_kineto_op(op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts)
+    if expected_result is not None:
+        assert result == sorted_kineto_cpu_ops[expected_result]
+    else:
+        assert result is None
 
 
 @pytest.mark.parametrize(
@@ -307,12 +493,17 @@ def test_link_ops(
 
     cpu_ev_idx_to_gpu_ops_map = {kineto_op.ev_idx: expected_linked_gpu_ops}
     kineto_rf_id_to_kineto_op_map = {1: MagicMock(spec=KinetoOperator, host_op=MagicMock(id=42))}
+    kineto_external_id_to_kineto_op_map = {
+        2: MagicMock(spec=KinetoOperator, host_op=MagicMock(id=3)),
+        3: MagicMock(spec=KinetoOperator, host_op=MagicMock(id=4)),
+    }
 
     result = trace_linker.link_ops(
         host_op,
         kineto_op,
         cpu_ev_idx_to_gpu_ops_map,
         kineto_rf_id_to_kineto_op_map,
+        kineto_external_id_to_kineto_op_map,
     )
 
     assert result == (
@@ -335,16 +526,19 @@ def test_link_ops_with_no_gpu_ops(trace_linker):
         timestamp=123456,
         host_op=None,
         inter_thread_dep=None,
+        sync_dep=[],
     )
 
     cpu_ev_idx_to_gpu_ops_map = {}
     kineto_rf_id_to_kineto_op_map = {}
+    kineto_external_id_to_kineto_op_map = {}
 
     result = trace_linker.link_ops(
         host_op,
         kineto_op,
         cpu_ev_idx_to_gpu_ops_map,
         kineto_rf_id_to_kineto_op_map,
+        kineto_external_id_to_kineto_op_map,
     )
 
     assert result == ([], 100, 50, 123456, None)
@@ -470,6 +664,7 @@ def test_process_dependent_gpu_ops(trace_linker, orig_op_id, cpu_op, kineto_gpu_
         gpu_op.exclusive_dur = gpu_op_data["exclusive_dur"]
         gpu_op.stream = gpu_op_data["stream"]
         gpu_op.pg_name = gpu_op_data.get("pg_name", None)
+        gpu_op.sync_dep = []
         kineto_gpu_op_objects.append(gpu_op)
 
     host_op_id_to_kineto_ops_map = {orig_op_id: kineto_gpu_op_objects}


### PR DESCRIPTION
## Summary
* This PR relies on https://github.com/mlcommons/chakra/pull/119. It can be merged after https://github.com/mlcommons/chakra/pull/119 is merged.

This PR introduces dependencies from GPU operators to CPU operators using the critical path analysis in HolisticTraceAnalysis (HTA). In the simulation flow of Chakra, postprocessors like the trace linker and the converter are required. They are responsible for merging Chakra host traces with Chakra device traces and encoding dependencies. Currently, the dependencies encoded by the postprocessors are limited to CPU operators to GPU operators. However, there can be dependencies from GPU operators to CPU operators if a CPU operator has a dependency on a GPU operator. To identify such dependencies, this PR utilizes the critical path analysis of HTA. More specifically, this PR uses the synchronization dependency of HTA. A synchronization dependency occurs when a CPU operator has to wait for a dispatched GPU operator to be completed. Therefore, synchronization dependency is the best for identifying such dependencies.
- HTA Repository: https://github.com/facebookresearch/HolisticTraceAnalysis
- HTA Critical Path Analysis Documentation: https://hta.readthedocs.io/en/latest/source/features/lightweight_critical_path_analysis.html
- HTA Critical Path Analysis Example: https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/examples/experimental/critical_path_analysis.ipynb

Please note that:
- The command has been changed. We need to specify the rank ID with `--rank` for chakra_trace_link.
- When collecting the trace, the Kineto trace profiler should collect nodes where the 'cat' field is 'cuda_sync'. Please follow the instructions here: (https://github.com/pytorch/pytorch/pull/105187).
```
from torch.autograd.profiler import profile, _ExperimentalConfig
with profile(use_kineto=True, use_cuda=True,
   experimental_config=_ExperimentalConfig(enable_cuda_sync_events=True),
) as prof:
   workload()
```

## Test Plan
Download and Install HTA.
```
git clone https://github.com/facebookresearch/HolisticTraceAnalysis.git
cd HolisticTraceAnalysis
git checkout d731cc2e2249976c97129d409a83bd53d93051f6
git submodule update --init
pip install -r requirements.txt
pip install -e .
```

Next, you need to collect traces by following the instructions here: https://github.com/pytorch/pytorch/pull/105187.

After that, you can load sync dependencies and print them out with the following script:
```
import argparse
import logging
import os
from typing import Dict, List

from hta.analyzers.critical_path_analysis import CPEdgeType
from hta.trace_analysis import TraceAnalysis

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)


def load_sync_dependencies(
    rank: int, kineto_file: str, annotation: str = "ProfilerStep", instance_id: int = 0
) -> Dict[int, List[int]]:
    """
    Load synchronization dependencies using Holistic Trace Analysis (HTA).

    Args:
        rank (int): Rank for the input Kineto trace.
        kineto_file (str): Path to the Kineto trace file.
        annotation (str): Annotation to use for the analysis. Defaults to "ProfilerStep".
        instance_id (int): Instance ID for the analysis. Defaults to 0.

    Returns:
        Dict[int, List[int]]: A dictionary mapping end event's external ID to a list of start event's external IDs
            that have synchronization dependencies.
    """
    sync_dependencies = {}
    trace_analysis = TraceAnalysis(trace_dir=os.path.dirname(kineto_file))
    cp_graph, success = trace_analysis.critical_path_analysis(rank=rank, annotation=annotation, instance_id=instance_id)
    if not success:
        logger.error("Failed to load Critical Path Graph")
        return sync_dependencies

    raw_events = trace_analysis.t.get_raw_trace_for_one_rank(rank=rank)["traceEvents"]
    for edge in cp_graph.critical_path_edges_set:
        if edge.type in [CPEdgeType.SYNC_DEPENDENCY]:
            start_event_id, end_event_id = cp_graph.get_events_for_edge(edge)
            start_event, end_event = raw_events[start_event_id], raw_events[end_event_id]
            if "External id" in end_event["args"] and "External id" in start_event["args"]:
                start_event_external_id = start_event["args"]["External id"]
                end_event_external_id = end_event["args"]["External id"]
                start_event_name = start_event["name"]
                end_event_name = end_event["name"]
                if start_event_external_id != end_event_external_id:
                    print(
                        f"start_event_id {start_event_id}, end_event_id {end_event_id}, "
                        f"start_event_external_id {start_event_external_id}, end_event_external_id {end_event_external_id}, "
                        f"start_event_name '{start_event_name}', end_event_name '{end_event_name}'"
                    )
            else:
                logger.warning(
                    f"Synchronization dependency from event {start_event_id} to event {end_event_id} will "
                    "not be considered due to missing external IDs."
                )
    return sync_dependencies


def main() -> None:
    """
    Main function to parse arguments and load synchronization dependencies.
    """
    parser = argparse.ArgumentParser(description="Load and print critical paths from Kineto traces.")
    parser.add_argument("--input", type=str, help="Path to the Kineto trace file.")
    parser.add_argument("--rank", type=int, help="Rank for the input traces.")
    args = parser.parse_args()

    load_sync_dependencies(args.rank, args.input)


if __name__ == "__main__":
    main()
```

You can run it with the following command:
```
$ python sync_dep.py --input ~/Downloads/cuda-sync/kineto_0.json --rank 0 > /tmp/out
```
[cuda-sync.zip](https://github.com/user-attachments/files/15990542/cuda-sync.zip)

/tmp/out
```
start_event_id 24868, end_event_id 24874, start_event_external_id 94785, end_event_external_id 94792, start_event_name 'void multi_tensor_apply_kernel<TensorListMetadata<6>, DistAdamWithParamRemaindersFunctor<float>, float*, float, float, float, float, float, float, adamMode_t, float>(long, int volatile*, TensorListMetadata<6>, DistAdamWithParamRemaindersFunctor<float>, float*, float, float, float, float, float, float, adamMode_t, float)', end_event_name 'cudaDeviceSynchronize'
start_event_id 24536, end_event_id 24650, start_event_external_id 13847, end_event_external_id 91874, start_event_name 'ncclDevKernel_ReduceScatter_Sum_f32_RING_LL(ncclDevComm*, unsigned long, ncclWork*)', end_event_name 'cudaDeviceSynchronize'
```

Two synchronization dependencies are identified with the script. In this test, we focus on the dependency between 'ncclDevKernel_ReduceScatter_Sum_f32_RING_LL(ncclDevComm*, unsigned long, ncclWork*)' and 'cudaDeviceSynchronize'.

Let's confirm our observation with a trace visualizer. You can read Kineto traces with https://perfetto.dev/. By searching for ncclDevKernel_ReduceScatter_Sum_f32_RING_LL, you can find that it is a GPU kernel (category field) with an external ID of 13847. Around the operator but in the CPU row of the visualization, you can find cudaDeviceSynchronize where the external ID is 94792. It is a cuda_runtime operator. As the cuda_runtime operator is not considered a simulatable operator in the toolchains, the closest but later CPU operator, aten::empty, with the external ID of 16392, should rely on the GPU kernel.

Let's see if the synchronization dependency is properly encoded in trace_link. Make sure you install Chakra.
```
$ pip install .
```

Run chakra_trace_link.
```
chakra_trace_link \
  --pytorch-et-file /Users/theo/Downloads/et_0.json\
  --kineto-file /Users/theo/Downloads/kineto_0.json\
  --output-file ~/megatron_0.json\
  --rank 0
```

You can review ~/megatron_0.json and find that sync dependencies are encoded.
```
        {
            "id": 15899,
            "name": "ncclDevKernel_ReduceScatter_Sum_f32_RING_LL(ncclDevComm*, unsigned long, ncclWork*)",
            "ctrl_deps": 15898,
            "inputs": {
                "values": [
                    [
                        87,
                        49,
                        576716800,
                        52428800,
                        4,
                        "cuda:0"
                    ],
                    [
                        90,
                        49,
                        629145600,
                        52428800,
                        4,
                        "cuda:0"
                    ]
                ],
                "shapes": [
                    [
                        52428800
                    ],
                    [
                        52428800
                    ]
                ],
                "types": [
                    "Tensor(float)",
                    "Tensor(float)"
                ]
            },
            "outputs": {
                "values": [],
                "shapes": [],
                "types": []
            },
            "attrs": [
                {
                    "name": "rf_id",
                    "type": "uint64",
                    "value": 13651
                },
                {
                    "name": "fw_parent",
                    "type": "uint64",
                    "value": 0
                },
                {
                    "name": "seq_id",
                    "type": "int64",
                    "value": -1
                },
                {
                    "name": "scope",
                    "type": "uint64",
                    "value": 7
                },
                {
                    "name": "tid",
                    "type": "uint64",
                    "value": 4
                },
                {
                    "name": "fw_tid",
                    "type": "uint64",
                    "value": 0
                },
                {
                    "name": "op_schema",
                    "type": "string",
                    "value": ""
                }
            ],
            "inclusive_dur": 44160,
            "exclusive_dur": 44160,
            "ts": 1719249141376319,
            "inter_thread_dep": 15685,
            "cat": "kernel",
            "ph": "X",
            "stream": 64
        },
        {
            "id": 15982,
            "name": "aten::detach",
            "ctrl_deps": 29,
            "inputs": {
                "values": [
                    [
                        20832,
                        1363,
                        0,
                        1,
                        4,
                        "cuda:0"
                    ]
                ],
                "shapes": [
                    []
                ],
                "types": [
                    "Tensor(float)"
                ]
            },
            "outputs": {
                "values": [
                    [
                        20842,
                        1363,
                        0,
                        1,
                        4,
                        "cuda:0"
                    ]
                ],
                "shapes": [
                    []
                ],
                "types": [
                    "Tensor(float)"
                ]
            },
            "attrs": [
                {
                    "name": "rf_id",
                    "type": "uint64",
                    "value": 13722
                },
                {
                    "name": "fw_parent",
                    "type": "uint64",
                    "value": 0
                },
                {
                    "name": "seq_id",
                    "type": "int64",
                    "value": 19404
                },
                {
                    "name": "scope",
                    "type": "uint64",
                    "value": 0
                },
                {
                    "name": "tid",
                    "type": "uint64",
                    "value": 1
                },
                {
                    "name": "fw_tid",
                    "type": "uint64",
                    "value": 0
                },
                {
                    "name": "op_schema",
                    "type": "string",
                    "value": "aten::detach(Tensor(a) self) -> Tensor(a)"
                }
            ],
            "inclusive_dur": 17,
            "exclusive_dur": 11,
            "ts": 1719249141527040,
            "inter_thread_dep": 15901,
            "sync_dep": 15899
        },

```

Run chakra_converter
```
chakra_converter --input_filename ~/megatron_0.json\
    --output_filename megatron_0.chakra\
    --input_type PyTorch\
     --log_filename /tmp/rank_0
```

Here are traces that I used. 
[cuda-sync.zip](https://github.com/user-attachments/files/15990542/cuda-sync.zip)
[Resnet-50.zip](https://github.com/mlcommons/chakra/files/15280405/Resnet-50.zip)
[llama2.zip](https://github.com/mlcommons/chakra/files/15280406/llama2.zip)