### PR TITLE
fixes is_cpu_op conversion in constructor

### DIFF
--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -14,7 +14,7 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
     const string& attr_name = attr.name();
 
     if (attr_name == "is_cpu_op") {
-      this->is_cpu_op_ = static_cast<uint32_t>(attr.int32_val());
+      this->is_cpu_op_ = static_cast<bool>(attr.bool_val());
     } else if (attr_name == "num_ops") {
       this->num_ops_ = static_cast<uint64_t>(attr.int64_val());
     } else if (attr_name == "tensor_size") {

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -53,7 +53,7 @@ class ETFeederNode {
 
   uint64_t id_;
   std::string name_;
-  uint32_t is_cpu_op_;
+  bool is_cpu_op_;
   uint64_t runtime_;
   uint64_t num_ops_;
   uint32_t tensor_loc_;


### PR DESCRIPTION
## Summary
This PR fixes the `is_cpu_op()` method which was always returning `false`, due to a `wrong conversion` in the constructor.
- the `is_cpu_op()` method is returning `bool`, but variable `is_cpu_op_` was of type `uint32_t` --> changed it to `bool`
- the conversion in the constructor of `ETFeederNode` was being done in `uint32_t` instead of `bool` --> changed it to `bool`
- in trace, the value for `is_cpu_op` attribute is a `bool`

## Test Plan
I've tested using `2 different traces`, converted them to `json` using `chakra_jsonizer` and checked if the `value returned by is_cpu_op()` method for a specific node is `the same with the one from the json`.