### PR TITLE
Refactor trace_link

### DIFF
--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -5,31 +5,25 @@ from param_bench.train.compute.python.tools.execution_trace import Node as PyTor
 
 class KinetoOperator:
     """
-    Represents a single operator in a Kineto trace by default, with fields primarily sourced
-    from the Kineto traces. In addition to the default fields from Kineto traces, additional
-    fields have been introduced for postprocessing purposes. These additional fields facilitate
-    the correlation of PyTorch operators and the enforcement of dependencies among them,
-    enhancing trace analysis and utility.
+    Represents a single operator in a Kineto trace.
 
     Attributes:
-        op_dict (Dict[str, Any]): Dictionary containing the operator data.
+        id (Optional[int]): Identifier of the operator.
         category (str): Category of the operator.
         name (str): Name of the operator.
-        phase (Optional[str]): Phase of the operator.
-        inclusive_dur (int): Inclusive duration of the operator in microseconds.
-        exclusive_dur (int): Exclusive duration of the operator in microseconds.
-        timestamp (int): Timestamp of the operator in microseconds.
-        external_id (str): External ID associated with the operator.
-        ev_idx (str): Event index associated with the operator.
-        tid (int): Thread ID associated with the operator.
-        pytorch_op (Optional[PyTorchOperator]): Associated PyTorch operator.
+        phase (Optional[str]): Execution phase of the operator.
+        inclusive_dur (int): Total duration of the operator, including its children.
+        exclusive_dur (int): Duration of the operator execution alone. Corresponds to the self time field in chrome://tracing.
+        timestamp (int): Start time of the operator in microseconds.
+        external_id (int): An external identifier associated with the operator.
+        ev_idx (int): Event index of the operator.
+        tid (int): Thread identifier where the operator was executed.
+        pytorch_op (Optional[PyTorchOperator]): Corresponding PyTorch operator object.
         parent_pytorch_op_id (Optional[int]): ID of the parent PyTorch operator.
-        inter_thread_dep (Optional[int]): ID of the latest CPU node from other
-            threads before the gap.
-        stream (Optional[int]): Stream ID associated with the operator.
-        rf_id (Optional[int]): Record function ID.
-        correlation (int): Correlation ID used to link CUDA runtime operations
-            with their GPU counterparts.
+        inter_thread_dep (Optional[int]): Identifier for inter-thread dependencies.
+        stream (Optional[int]): CUDA stream identifier associated with the operator.
+        rf_id (Optional[int]): Record function identifier.
+        correlation (int): Identifier used to correlate CUDA runtime and GPU operations.
     """
 
     def __init__(self, kineto_op: Dict[str, Any]) -> None:
@@ -40,21 +34,21 @@ class KinetoOperator:
             kineto_op (Dict[str, Any]): The dictionary representing the
                                         operator data.
         """
-        self.op_dict: Dict[str, Any] = kineto_op
+        self.id: Optional[int] = kineto_op.get("id")
         self.category: str = kineto_op.get("cat", "")
         self.name: str = kineto_op.get("name", "")
         self.phase: Optional[str] = kineto_op.get("ph")
         self.inclusive_dur: int = kineto_op.get("dur", 0)
         self.exclusive_dur: int = kineto_op.get("dur", 0)
         self.timestamp: int = kineto_op.get("ts", 0)
-        self.external_id: str = kineto_op.get("args", {}).get("External id", "")
-        self.ev_idx: str = kineto_op.get("args", {}).get("Ev Idx", "")
+        self.external_id: int = int(kineto_op.get("args", {}).get("External id", -1))
+        self.ev_idx: int = int(kineto_op.get("args", {}).get("Ev Idx", -1))
         self.tid: int = kineto_op.get("tid", 0)
         self.pytorch_op: Optional[PyTorchOperator] = None
         self.parent_pytorch_op_id: Optional[int] = None
         self.inter_thread_dep: Optional[int] = None
-        self.stream: Optional[int] = kineto_op.get("args", {}).get("stream")
-        self.rf_id: Optional[int] = kineto_op.get("args", {}).get("Record function id")
+        self.stream: Optional[int] = kineto_op.get("args", {}).get("stream", None)
+        self.rf_id: Optional[int] = kineto_op.get("args", {}).get("Record function id", None)
         self.correlation: int = kineto_op.get("args", {}).get("correlation", -1)
 
     def __repr__(self) -> str:
@@ -65,40 +59,65 @@ class KinetoOperator:
             str: A string representation of the KinetoOperator.
         """
         return (
-            f"KinetoOperator(category={self.category}, name={self.name}, phase={self.phase}, "
-            f"inclusive_dur={self.inclusive_dur}, exclusive_dur={self.exclusive_dur}, "
-            f"timestamp={self.timestamp}, external_id={self.external_id}, ev_idx={self.ev_idx}, "
-            f"tid={self.tid}, parent_pytorch_op_id={self.parent_pytorch_op_id}, "
-            f"inter_thread_dep={self.inter_thread_dep}, stream={self.stream}, rf_id={self.rf_id}, "
-            f"correlation={self.correlation})"
+            f"KinetoOperator(id={self.id}, category={self.category}, name={self.name}, "
+            f"phase={self.phase}, inclusive_dur={self.inclusive_dur}, "
+            f"exclusive_dur={self.exclusive_dur}, timestamp={self.timestamp}, "
+            f"external_id={self.external_id}, ev_idx={self.ev_idx}, tid={self.tid}, "
+            f"parent_pytorch_op_id={self.parent_pytorch_op_id}, inter_thread_dep={self.inter_thread_dep}, "
+            f"stream={self.stream}, rf_id={self.rf_id}, correlation={self.correlation})"
         )
 
-    def is_valid(
-        self,
-        category: str,
-        name_exception: str = "ProfilerStep",
-        phase: Optional[str] = None,
-    ) -> bool:
+    def is_cpu_op(self) -> bool:
         """
-        Checks if the operator matches specified filtering criteria.
-
-        Comment (TODO):
-            This is legacy code from a previous implementation. Ideally, we should merge this logic
-            into trace_linker.py. The purpose of is_valid is ambiguous, and it is unclear whether
-            the function is essential. However, we keep it as it is to avoid breaking downstream
-            tools. After properly setting up CI/CD pipelines and testing, we can consider removing it.
-
-        Args:
-            category (str): The category to check against.
-            name_exception (str): A name to exclude in the check.
-            phase (Optional[str]): The phase to check against, if any.
+        Determines if the operator is simulatable based on its category and name.
+        The categories 'cpu_op' and 'user_annotation' are considered CPU operators.
+        Notably, 'user_annotation' operators often include the duration of CPU operator launch times.
+        Ignoring the duration measured in 'user_annotation' can lead to inaccuracies in simulation.
+        An exception to this is 'ProfilerStep', which should be completely ignored.
+        Ideally, a more general rule should be developed to identify such exception nodes.
 
         Returns:
-            bool: True if the operator matches the criteria, False otherwise.
+            bool: True if the operator is simulatable, False otherwise.
         """
-        return (
-            self.category is not None
-            and name_exception not in self.name
-            and self.category == category
-            and (phase is None or self.phase == phase)
-        )
+        simulatable_categories = {"cpu_op", "user_annotation"}
+        name_exceptions = {"ProfilerStep"}
+        if self.category in simulatable_categories and all(exc not in self.name for exc in name_exceptions):
+            return True
+        return False
+
+    def is_cuda_launch_op(self) -> bool:
+        """
+        Determines whether the operator is a kernel-launching CUDA runtime operator.
+
+        Returns:
+            bool: True if it's a launch operation, otherwise False.
+        """
+        cuda_launch_categories = {"cuda_runtime", "cuda_driver"}
+        cuda_launch_operations = {
+            "cudaLaunchKernel",
+            "cudaLaunchKernelExC",
+            "cudaMemcpy",
+            "cudaMemcpyAsync",
+            "cudaMemcpyToSymbol",
+            "cudaMemcpyFromSymbol",
+        }
+        return self.category in cuda_launch_categories and self.name in cuda_launch_operations
+
+    def is_gpu_op(self) -> bool:
+        """
+        Checks if the operator is a GPU-side operator based on its category.
+
+        Returns:
+            bool: True if it's a GPU-side operation, otherwise False.
+        """
+        gpu_categories = {"kernel", "gpu_memcpy"}
+        return self.category in gpu_categories
+
+    def is_arrow_op(self) -> bool:
+        """
+        Checks if the operator is categorized as 'ac2g', which stands for arrows from CPU to GPU.
+
+        Returns:
+            bool: True if the operator is an 'ac2g' type, otherwise False.
+        """
+        return self.category == "ac2g"

--- a/src/trace_link/unique_id_assigner.py
+++ b/src/trace_link/unique_id_assigner.py
@@ -5,16 +5,14 @@ class UniqueIdAssigner:
     """
     Assigns unique IDs to items, ensuring each item gets a distinct ID.
 
-    This class is used to maintain a consistent and unique mapping of original
-    identifiers to new unique identifiers. It's particularly useful in scenarios
-    where the uniqueness of IDs across different entities or iterations needs to
+    This class is used to maintain a consistent and unique mapping of original identifiers to new unique identifiers.
+    It's particularly useful in scenarios where the uniqueness of IDs across different entities or iterations needs to
     be preserved.
 
     Attributes:
         next_id (int): The next unique ID to be assigned.
-        original_to_new_ids (Dict[int, int]): A mapping from original IDs to their
-            corresponding new unique IDs. This helps in retrieving already assigned
-            unique IDs and ensures the same original ID always maps to the same
+        original_to_new_ids (Dict[int, int]): A mapping from original IDs to their corresponding new unique IDs. This
+            helps in retrieving already assigned unique IDs and ensures the same original ID always maps to the same
             unique ID.
     """
 
@@ -22,13 +20,13 @@ class UniqueIdAssigner:
         """
         Initializes the UniqueIdAssigner with a starting ID of 0.
         """
-        self.next_id = 0
+        self.next_id: int = 0
         self.original_to_new_ids: Dict[int, int] = {}
 
     def assign_or_retrieve_id(self, original_id: int) -> int:
         """
-        Assigns a new unique ID to the given original ID if it doesn't have one already;
-        otherwise, returns the previously assigned unique ID.
+        Assigns a new unique ID to the given original ID if it doesn't have one already; otherwise, returns the
+        previously assigned unique ID.
 
         Args:
             original_id (int): The original ID for which a unique ID is needed.
@@ -46,8 +44,7 @@ class UniqueIdAssigner:
         """
         Generates a new unique ID without needing an original ID.
 
-        This is useful for cases where new entities are created that do not
-        have an existing identifier.
+        This is useful for cases where new entities are created that do not have an existing identifier.
 
         Returns:
             int: A new unique ID.
@@ -60,14 +57,12 @@ class UniqueIdAssigner:
         """
         Retrieves the new unique ID for a given original ID, if it has been assigned.
 
-        This method is useful for checking if a unique ID has already been
-        assigned to an original ID and retrieving it.
+        This method is useful for checking if a unique ID has already been assigned to an original ID and retrieving it.
 
         Args:
             original_id (int): The original ID to look up.
 
         Returns:
-            int: The new unique ID if it has been assigned, otherwise returns
-                the original ID.
+            int: The new unique ID if it has been assigned, otherwise returns the original ID.
         """
         return self.original_to_new_ids.get(original_id, original_id)

--- a/tests/trace_link/test_kineto_operator.py
+++ b/tests/trace_link/test_kineto_operator.py
@@ -13,7 +13,7 @@ def sample_operator_data():
         "dur": 100,
         "ts": 1590000000,
         "tid": 1234,
-        "args": {"External id": "ext123", "Ev Idx": "ev456", "stream": 7, "Record function id": 12, "correlation": 99},
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
     }
 
 
@@ -26,8 +26,8 @@ def test_init_kineto_operator(sample_operator_data):
     assert operator.inclusive_dur == 100
     assert operator.exclusive_dur == 100
     assert operator.timestamp == 1590000000
-    assert operator.external_id == "ext123"
-    assert operator.ev_idx == "ev456"
+    assert operator.external_id == 123
+    assert operator.ev_idx == 456
     assert operator.tid == 1234
     assert operator.stream == 7
     assert operator.rf_id == 12
@@ -41,20 +41,9 @@ def test_repr_method(sample_operator_data):
     """Test the __repr__ method output."""
     operator = KinetoOperator(sample_operator_data)
     expected_repr = (
-        "KinetoOperator(category=Kernel, name=cudaLaunchKernel, phase=X, "
-        "inclusive_dur=100, exclusive_dur=100, timestamp=1590000000, external_id=ext123, ev_idx=ev456, "
+        "KinetoOperator(id=None, category=Kernel, name=cudaLaunchKernel, phase=X, "
+        "inclusive_dur=100, exclusive_dur=100, timestamp=1590000000, external_id=123, ev_idx=456, "
         "tid=1234, parent_pytorch_op_id=None, inter_thread_dep=None, stream=7, rf_id=12, "
         "correlation=99)"
     )
     assert repr(operator) == expected_repr
-
-
-def test_is_valid_method(sample_operator_data):
-    """Test the is_valid method under various conditions."""
-    operator = KinetoOperator(sample_operator_data)
-    assert operator.is_valid(category="Kernel")  # Matching category
-    assert not operator.is_valid(category="Memory")  # Non-matching category
-    assert operator.is_valid(category="Kernel", name_exception="cudaMalloc")  # Matching category, name not excluded
-    assert not operator.is_valid(category="Kernel", name_exception="cudaLaunchKernel")  # Name excluded
-    assert operator.is_valid(category="Kernel", phase="X")  # Matching phase
-    assert not operator.is_valid(category="Kernel", phase="B")  # Non-matching phase


### PR DESCRIPTION
## Summary
Refactor trace_link.
- Updated the maximum column length to 120.
- Improved the documentation in docstrings.
- Renamed functions to improve readability (construct_kineto_data_structures, is_cpu_op, is_gpu_op, is_cuda_launch_op).
- Added missing type annotations.

## Test Plan
```
$ pip install . 
Processing /Users/theo/chakra-official
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: protobuf==4.* in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (4.23.4)
Requirement already satisfied: graphviz in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (0.20.1)
Requirement already satisfied: networkx in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (3.2.1)
Requirement already satisfied: pydot in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (2.0.0)
Requirement already satisfied: pyparsing>=3 in /Users/theo/venv/lib/python3.10/site-packages (from pydot->chakra==0.0.4) (3.1.1)
Building wheels for collected packages: chakra
  Building wheel for chakra (pyproject.toml) ... done
  Created wheel for chakra: filename=chakra-0.0.4-py3-none-any.whl size=50669 sha256=46069a8eb816bc3497e0a094676bd6feaa4241ad19117c569df08c8eeab802fc
  Stored in directory: /Users/theo/Library/Caches/pip/wheels/a7/4b/e3/99576bcd5b74d73e757364a32af2372bf8fc73262affb0c1e4
Successfully built chakra
Installing collected packages: chakra
  Attempting uninstall: chakra
    Found existing installation: chakra 0.0.4
    Uninstalling chakra-0.0.4:
      Successfully uninstalled chakra-0.0.4

$ python3 ci_tools/integration_tests.py --tgz_path tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz --num_ranks 8 --tolerance 0.05 --expected_times_ms 14597 14597 14968 14638 14649 14700 14677 14735
Extracting tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz to tests/data/1.0.2-chakra.0.0.4
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_0.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_0.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_1.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_1.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_2.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_2.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_3.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_3.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_4.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_4.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_5.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_5.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_6.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_6.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_7.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_7.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_0.chakra --input_type PyTorch --log_filename /tmp/rank_0.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_1.chakra --input_type PyTorch --log_filename /tmp/rank_1.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_2.chakra --input_type PyTorch --log_filename /tmp/rank_2.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_3.chakra --input_type PyTorch --log_filename /tmp/rank_3.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_4.chakra --input_type PyTorch --log_filename /tmp/rank_4.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_5.chakra --input_type PyTorch --log_filename /tmp/rank_5.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_6.chakra --input_type PyTorch --log_filename /tmp/rank_6.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_7.chakra --input_type PyTorch --log_filename /tmp/rank_7.log
Validation successful for /tmp/rank_0.log: 14802300us is within the acceptable range.
Validation successful for /tmp/rank_1.log: 14785782us is within the acceptable range.
Validation successful for /tmp/rank_2.log: 15233261us is within the acceptable range.
Validation successful for /tmp/rank_3.log: 14878058us is within the acceptable range.
Validation successful for /tmp/rank_4.log: 14892945us is within the acceptable range.
Validation successful for /tmp/rank_5.log: 14993779us is within the acceptable range.
Validation successful for /tmp/rank_6.log: 14936348us is within the acceptable range.
Validation successful for /tmp/rank_7.log: 15031147us is within the acceptable range.
```