### PR TITLE
Add docstrings and enhance help messages in visualizer

### DIFF
--- a/src/visualizer/visualizer.py
+++ b/src/visualizer/visualizer.py
@@ -6,10 +6,7 @@ import re
 import graphviz
 import networkx as nx
 
-from ...schema.protobuf.et_def_pb2 import (
-    GlobalMetadata,
-    Node,
-)
+from ...schema.protobuf.et_def_pb2 import GlobalMetadata, Node
 from ..third_party.utils.protolib import decodeMessage as decode_message
 from ..third_party.utils.protolib import openFileRd as open_file_rd
 
@@ -31,11 +28,23 @@ def escape_label(label: str) -> str:
 
 
 def main() -> None:
+    """
+    Main function for the Execution Trace Visualizer.
+
+    This function parses command-line arguments, reads the input Chakra execution trace file,
+    and generates an output graph file in the specified format (PDF, DOT, or GraphML).
+    """
     parser = argparse.ArgumentParser(description="Execution Trace Visualizer")
+    parser.add_argument("--input_filename", type=str, required=True, help="Input Chakra execution trace filename")
     parser.add_argument(
-        "--input_filename", type=str, default=None, required=True, help="Input Chakra execution trace filename"
+        "--output_filename",
+        type=str,
+        required=True,
+        help=(
+            "Output graph filename. Supported extensions are pdf, dot, and graphml. "
+            "Recommend using graphml for large graphs for rendering speed."
+        ),
     )
-    parser.add_argument("--output_filename", type=str, default=None, required=True, help="Output graph filename")
     args = parser.parse_args()
 
     et = open_file_rd(args.input_filename)


### PR DESCRIPTION
## Summary
Add docstrings and enhance help messages in visualizer

## Test Plan
```
$ chakra_visualizer --help
usage: chakra_visualizer [-h] --input_filename INPUT_FILENAME --output_filename OUTPUT_FILENAME

Execution Trace Visualizer

options:
  -h, --help            show this help message and exit
  --input_filename INPUT_FILENAME
                        Input Chakra execution trace filename
  --output_filename OUTPUT_FILENAME
                        Output graph filename. Supported extensions are pdf, dot, and graphml. Recommend
                        using graphml for large graphs for rendering speed.
```
```
$ chakra_visualizer --input_filename megatron_0.chakra --output_filename megatron_0.graphml 
$ head megatron_0.graphml 
<?xml version='1.0' encoding='utf-8'?>
<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
  <key id="d1" for="edge" attr.name="dependency" attr.type="string" />
  <key id="d0" for="node" attr.name="label" attr.type="string" />
  <graph edgedefault="directed">
    <node id="1">
      <data key="d0">[pytorch|profiler|execution_trace|thread]</data>
    </node>
    <node id="0" />
    <node id="2">
```