### PR TITLE
 Refactor TraceLinker for improved testability 

### DIFF
--- a/src/trace_link/trace_link.py
+++ b/src/trace_link/trace_link.py
@@ -31,11 +31,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    linker = TraceLinker(args.pytorch_et_file, args.kineto_file, args.log_level)
-    linker.load_traces()
-    linker.enforce_inter_thread_order()
-    linker.link_traces()
-    linker.dump_pytorch_execution_trace_plus(args.output_file)
+    linker = TraceLinker(args.log_level)
+    linker.link(args.pytorch_et_file, args.kineto_file, args.output_file)
 
 
 if __name__ == "__main__":

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -104,8 +104,23 @@ class TraceLinker:
         self.pytorch_et_file = pytorch_et_file
         self.kineto_file = kineto_file
         self.pytorch_ops, kineto_data = self.load_traces(pytorch_et_file, kineto_file)
-        self.update_kineto_data(kineto_data)
-        self.enforce_inter_thread_order()
+
+        (
+            self.kineto_cpu_ops,
+            self.kineto_tid_cpu_ops_map,
+            self.kineto_correlation_cuda_runtime_map,
+            self.kineto_gpu_ops,
+            self.kineto_id_arrow_op_map,
+            self.kineto_id_cuda_launch_op_map,
+            self.kineto_process_start_time,
+            self.kineto_process_end_time,
+            self.kineto_thread_info,
+            self.kineto_rf_id_to_kineto_op_map,
+            self.sorted_kineto_cpu_ops,
+            self.sorted_kineto_cpu_op_ts,
+        ) = self.update_kineto_data(kineto_data)
+
+        self.kineto_tid_cpu_ops_map = self.enforce_inter_thread_order(self.kineto_tid_cpu_ops_map)
         self.link_traces()
         self.dump_pytorch_execution_trace_plus(output_file)
 
@@ -373,27 +388,47 @@ class TraceLinker:
 
         return merged
 
-    def update_kineto_data(self, kineto_data: Dict) -> None:
+    def update_kineto_data(self, kineto_data: Dict) -> Tuple:
         """
         Update the variables of the TraceLinker class using the data structures from the kineto_data dictionary.
 
         Args:
             kineto_data (Dict): Dictionary containing categorized operators and timing boundaries.
-        """
-        self.kineto_cpu_ops = kineto_data["kineto_cpu_ops"]
-        self.kineto_tid_cpu_ops_map = kineto_data["kineto_tid_cpu_ops_map"]
-        self.kineto_correlation_cuda_runtime_map = kineto_data["kineto_correlation_cuda_runtime_map"]
-        self.kineto_gpu_ops = kineto_data["kineto_gpu_ops"]
-        self.kineto_id_arrow_op_map = kineto_data["kineto_id_arrow_op_map"]
-        self.kineto_id_cuda_launch_op_map = kineto_data["kineto_id_cuda_launch_op_map"]
-        self.kineto_process_start_time = kineto_data["kineto_process_start_time"]
-        self.kineto_process_end_time = kineto_data["kineto_process_end_time"]
-        self.kineto_thread_info = kineto_data["kineto_thread_info"]
-        self.kineto_rf_id_to_kineto_op_map = {op.rf_id: op for op in self.kineto_cpu_ops if op.rf_id is not None}
-        self.sorted_kineto_cpu_ops = kineto_data["sorted_kineto_cpu_ops"]
-        self.sorted_kineto_cpu_op_ts = kineto_data["sorted_kineto_cpu_op_ts"]
 
-    def enforce_inter_thread_order(self, threshold: int = 1000) -> None:
+        Returns:
+            Tuple: Contains all updated variables from the kineto_data dictionary.
+        """
+        kineto_cpu_ops = kineto_data["kineto_cpu_ops"]
+        kineto_tid_cpu_ops_map = kineto_data["kineto_tid_cpu_ops_map"]
+        kineto_correlation_cuda_runtime_map = kineto_data["kineto_correlation_cuda_runtime_map"]
+        kineto_gpu_ops = kineto_data["kineto_gpu_ops"]
+        kineto_id_arrow_op_map = kineto_data["kineto_id_arrow_op_map"]
+        kineto_id_cuda_launch_op_map = kineto_data["kineto_id_cuda_launch_op_map"]
+        kineto_process_start_time = kineto_data["kineto_process_start_time"]
+        kineto_process_end_time = kineto_data["kineto_process_end_time"]
+        kineto_thread_info = kineto_data["kineto_thread_info"]
+        kineto_rf_id_to_kineto_op_map = {op.rf_id: op for op in kineto_cpu_ops if op.rf_id is not None}
+        sorted_kineto_cpu_ops = kineto_data["sorted_kineto_cpu_ops"]
+        sorted_kineto_cpu_op_ts = kineto_data["sorted_kineto_cpu_op_ts"]
+
+        return (
+            kineto_cpu_ops,
+            kineto_tid_cpu_ops_map,
+            kineto_correlation_cuda_runtime_map,
+            kineto_gpu_ops,
+            kineto_id_arrow_op_map,
+            kineto_id_cuda_launch_op_map,
+            kineto_process_start_time,
+            kineto_process_end_time,
+            kineto_thread_info,
+            kineto_rf_id_to_kineto_op_map,
+            sorted_kineto_cpu_ops,
+            sorted_kineto_cpu_op_ts,
+        )
+
+    def enforce_inter_thread_order(
+        self, kineto_tid_cpu_ops_map: Dict[int, List[KinetoOperator]], threshold: int = 1000
+    ) -> Dict[int, List[KinetoOperator]]:
         """
         Enforce order between groups of operators in different threads.
 
@@ -406,39 +441,18 @@ class TraceLinker:
         on the last CPU operator from other threads, enforcing order and dependency across threads.
 
         Args:
+            kineto_tid_cpu_ops_map (Dict[int, List[KinetoOperator]]): Kineto CPU operators grouped by thread ID.
             threshold (int): Threshold for significant gap detection in microseconds, used to define group boundaries.
+
+        Returns:
+            Dict[int, List[KinetoOperator]]: Updated map with enforced inter-thread order.
         """
         self.logger.info("Enforcing inter-thread order in Kineto traces.")
 
-        def process_thread(
-            tid: int,
-            ops: List[KinetoOperator],
-            ops_by_tid: Dict[int, List[KinetoOperator]],
-        ) -> None:
-            self.logger.info(f"Thread {tid}: Identifying gaps for dependency linking with threshold {threshold}us.")
-            sorted_ops = sorted(ops, key=lambda op: op.timestamp)
-            last_cpu_node_rf_id = None
-
-            for i, op in enumerate(sorted_ops):
-                if (
-                    i == 0
-                    or (sorted_ops[i].timestamp - sorted_ops[i - 1].timestamp - sorted_ops[i - 1].inclusive_dur)
-                    > threshold
-                ):
-                    last_cpu_node_rf_id = self.find_last_cpu_node_before_timestamp(ops_by_tid, tid, op.timestamp)
-                    if last_cpu_node_rf_id:
-                        self.logger.debug(
-                            f"Thread {tid}: Linking op '{op.name}' to CPU node before gap with rf_id "
-                            f"'{last_cpu_node_rf_id}'."
-                        )
-
-                if last_cpu_node_rf_id:
-                    op.inter_thread_dep = last_cpu_node_rf_id
-
         with ThreadPoolExecutor() as executor:
             futures = {
-                executor.submit(process_thread, tid, ops, self.kineto_tid_cpu_ops_map): tid
-                for tid, ops in self.kineto_tid_cpu_ops_map.items()
+                executor.submit(self.process_thread, tid, ops, kineto_tid_cpu_ops_map, threshold): tid
+                for tid, ops in kineto_tid_cpu_ops_map.items()
             }
 
             for future in as_completed(futures):
@@ -448,6 +462,39 @@ class TraceLinker:
                     self.logger.debug(f"Thread {tid} dependencies processed.")
                 except Exception as e:
                     self.logger.error(f"Error processing thread {tid}: {e}")
+
+        return kineto_tid_cpu_ops_map
+
+    def process_thread(
+        self, tid: int, ops: List[KinetoOperator], ops_by_tid: Dict[int, List[KinetoOperator]], threshold: int
+    ) -> None:
+        """
+        Process a single thread's operators to enforce inter-thread order.
+
+        Args:
+            tid (int): Thread ID.
+            ops (List[KinetoOperator]): List of Kineto operators for the thread.
+            ops_by_tid (Dict[int, List[KinetoOperator]]): Kineto operators grouped by thread ID.
+            threshold (int): Threshold for significant gap detection in microseconds.
+        """
+        self.logger.info(f"Thread {tid}: Identifying gaps for dependency linking with threshold {threshold}us.")
+        sorted_ops = sorted(ops, key=lambda op: op.timestamp)
+        last_cpu_node_rf_id = None
+
+        for i, op in enumerate(sorted_ops):
+            if (
+                i == 0
+                or (sorted_ops[i].timestamp - sorted_ops[i - 1].timestamp - sorted_ops[i - 1].inclusive_dur) > threshold
+            ):
+                last_cpu_node_rf_id = self.find_last_cpu_node_before_timestamp(ops_by_tid, tid, op.timestamp)
+                if last_cpu_node_rf_id:
+                    self.logger.debug(
+                        f"Thread {tid}: Linking op '{op.name}' to CPU node before gap with rf_id "
+                        f"'{last_cpu_node_rf_id}'."
+                    )
+
+            if last_cpu_node_rf_id:
+                op.inter_thread_dep = last_cpu_node_rf_id
 
     def find_last_cpu_node_before_timestamp(
         self,

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -60,17 +60,15 @@ class TraceLinker:
         logger (logging.Logger): Logger for the class.
     """
 
-    def __init__(self, pytorch_et_file: str, kineto_file: str, log_level: str = "INFO") -> None:
+    def __init__(self, log_level: str = "INFO") -> None:
         """
-        Initialize the TraceLinker with paths to the PyTorch and Kineto trace files, and a log level.
+        Initialize the TraceLinker with a log level.
 
         Args:
-            pytorch_et_file (str): Path to the PyTorch execution trace file.
-            kineto_file (str): Path to the Kineto trace file.
             log_level (str): Logging level for the class.
         """
-        self.pytorch_et_file: str = pytorch_et_file
-        self.kineto_file: str = kineto_file
+        self.pytorch_et_file: str = ""
+        self.kineto_file: str = ""
         self.pytorch_ops: List[PyTorchOperator] = []
         self.kineto_cpu_ops: List[KinetoOperator] = []
         self.sorted_kineto_cpu_ops: List[KinetoOperator] = []
@@ -93,6 +91,22 @@ class TraceLinker:
         self.pytorch_et_plus_data: Optional[Dict] = None
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.logger.setLevel(log_level.upper())
+
+    def link(self, pytorch_et_file: str, kineto_file: str, output_file: str) -> None:
+        """
+        High-level method to link traces and produce the ET+ file.
+
+        Args:
+            pytorch_et_file (str): Path to the PyTorch execution trace file.
+            kineto_file (str): Path to the Kineto trace file.
+            output_file (str): Path for the output PyTorch execution trace plus file.
+        """
+        self.pytorch_et_file = pytorch_et_file
+        self.kineto_file = kineto_file
+        self.load_traces()
+        self.enforce_inter_thread_order()
+        self.link_traces()
+        self.dump_pytorch_execution_trace_plus(output_file)
 
     def load_traces(self) -> None:
         """Load both PyTorch Execution Traces and Kineto Traces."""

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -25,15 +25,11 @@ def test_initialization(trace_linker):
 
 @patch("chakra.src.trace_link.trace_linker.TraceLinker.load_pytorch_et")
 @patch("chakra.src.trace_link.trace_linker.TraceLinker.load_kineto_trace")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.update_kineto_data")
-def test_load_traces(mock_update_kineto_data, mock_load_kineto_trace, mock_load_pytorch_et, trace_linker):
+def test_load_traces(mock_load_kineto_trace, mock_load_pytorch_et, trace_linker):
     mock_load_kineto_trace.return_value = {"sample_data": "data"}
-    trace_linker.pytorch_et_file = "path/to/pytorch_et.json"
-    trace_linker.kineto_file = "path/to/kineto.json"
-    trace_linker.load_traces()
+    trace_linker.load_traces("path/to/pytorch_et.json", "path/to/kineto.json")
     mock_load_pytorch_et.assert_called_once()
     mock_load_kineto_trace.assert_called_once()
-    mock_update_kineto_data.assert_called_once_with({"sample_data": "data"})
 
 
 def test_construct_kineto_data_structures(trace_linker):

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -15,12 +15,10 @@ from param_bench.train.compute.python.tools.execution_trace import (
 
 @pytest.fixture
 def trace_linker():
-    return TraceLinker(pytorch_et_file="path/to/pytorch_et.json", kineto_file="path/to/kineto.json")
+    return TraceLinker(log_level="INFO")
 
 
 def test_initialization(trace_linker):
-    assert trace_linker.pytorch_et_file == "path/to/pytorch_et.json"
-    assert trace_linker.kineto_file == "path/to/kineto.json"
     assert isinstance(trace_linker.id_assigner, UniqueIdAssigner)
     assert trace_linker.logger.name == "chakra.src.trace_link.trace_linker"
 
@@ -30,6 +28,8 @@ def test_initialization(trace_linker):
 @patch("chakra.src.trace_link.trace_linker.TraceLinker.update_kineto_data")
 def test_load_traces(mock_update_kineto_data, mock_load_kineto_trace, mock_load_pytorch_et, trace_linker):
     mock_load_kineto_trace.return_value = {"sample_data": "data"}
+    trace_linker.pytorch_et_file = "path/to/pytorch_et.json"
+    trace_linker.kineto_file = "path/to/kineto.json"
     trace_linker.load_traces()
     mock_load_pytorch_et.assert_called_once()
     mock_load_kineto_trace.assert_called_once()


### PR DESCRIPTION
## Summary
Refactor TraceLinker for improved testability 

## Test Plan
```
$ pip install .   
Processing /Users/theo/chakra
py  Installing build dependencies ... -th\|3done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: protobuf==4.* in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (4.23.4)
Requirement already satisfied: graphviz in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (0.20.1)
Requirement already satisfied: networkx in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (3.2.1)
Requirement already satisfied: pydot in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (2.0.0)
Requirement already satisfied: pyparsing>=3 in /Users/theo/venv/lib/python3.10/site-packages (from pydot->chakra==0.0.4) (3.1.1)
Building wheels for collected packages: chakra
  Building wheel for chakra (pyproject.toml) ... done
  Created wheel for chakra: filename=chakra-0.0.4-py3-none-any.whl size=52293 sha256=bd36dfcdafbc3315738d32e88aa694bb713297e88d38cb8b929debe32296f3d8
  Stored in directory: /private/var/folders/z0/c9mq5j4s6n14n0_gs7nlt6mc0000gp/T/pip-ephem-wheel-cache-4v6nimk8/wheels/fa/dc/75/2163b4163bf1e9cf3c7f1cf69fa03716fb707b8c4f5cb271e8
Successfully built chakra
Installing collected packages: chakra
  Attempting uninstall: chakra
    Found existing installation: chakra 0.0.4
    Uninstalling chakra-0.0.4:
      Successfully uninstalled chakra-0.0.4
Successfully installed chakra-0.0.4

$ python3 ci_tools/integration_tests.py --tgz_path tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz --num_ranks 8 --tolerance 0.05 --expected_times_ms 14597 14597 14968 14638 14649 14700 14677 14735
Extracting tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz to tests/data/1.0.2-chakra.0.0.4
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_0.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_0.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_1.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_1.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_2.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_2.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_3.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_3.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_4.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_4.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_5.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_5.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_6.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_6.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_7.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_7.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_0.chakra --input_type PyTorch --log_filename /tmp/rank_0.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_1.chakra --input_type PyTorch --log_filename /tmp/rank_1.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_2.chakra --input_type PyTorch --log_filename /tmp/rank_2.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_4.chakra --input_type PyTorch --log_filename /tmp/rank_4.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_3.chakra --input_type PyTorch --log_filename /tmp/rank_3.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_6.chakra --input_type PyTorch --log_filename /tmp/rank_6.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_5.chakra --input_type PyTorch --log_filename /tmp/rank_5.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_7.chakra --input_type PyTorch --log_filename /tmp/rank_7.log
Validation successful for /tmp/rank_0.log: 14802300us is within the acceptable range.
Validation successful for /tmp/rank_1.log: 14785782us is within the acceptable range.
Validation successful for /tmp/rank_2.log: 15233261us is within the acceptable range.
Validation successful for /tmp/rank_3.log: 14878058us is within the acceptable range.
Validation successful for /tmp/rank_4.log: 14892945us is within the acceptable range.
Validation successful for /tmp/rank_5.log: 14993779us is within the acceptable range.
Validation successful for /tmp/rank_6.log: 14936348us is within the acceptable range.
Validation successful for /tmp/rank_7.log: 15031147us is within the acceptable range.
```