### PR TITLE
Solve attr[is_cpu_op] et_feeder parsing error

### DIFF
--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -14,7 +14,7 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
     const string& attr_name = attr.name();
 
     if (attr_name == "is_cpu_op") {
-      this->is_cpu_op_ = static_cast<bool>(attr.bool_val());
+      this->is_cpu_op_ = static_cast<bool>(attr.int32_val());
     } else if (attr_name == "num_ops") {
       this->num_ops_ = static_cast<uint64_t>(attr.int64_val());
     } else if (attr_name == "tensor_size") {


### PR DESCRIPTION
## Summary
Solve attr[is_cpu_op] et_feeder parsing error.

## Test Plan


## Additional Notes
is_cpu_op_ in attr is of type int32, but attr.bool_val() is used to read it in et_feeder, which will cause parsing errors.