### PR TITLE
Encode is_cpu_op as a boolean value in the converter

### DIFF
--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -337,7 +337,7 @@ class PyTorchConverter:
                 ChakraAttr(name="tid", int64_val=pytorch_node.tid),
                 ChakraAttr(name="fw_tid", int64_val=pytorch_node.fw_tid),
                 ChakraAttr(name="op_schema", string_val=pytorch_node.op_schema),
-                ChakraAttr(name="is_cpu_op", int32_val=not pytorch_node.is_gpu_op()),
+                ChakraAttr(name="is_cpu_op", bool_val=not pytorch_node.is_gpu_op()),
             ]
         )
         return chakra_node


### PR DESCRIPTION
## Summary
Encode is_cpu_op as a boolean value in the converter. Previously, the converter encoded is_cpu_op as an int32_t, which led to a bug in the parsing logic and the CI pipelines. This PR fixes the bug and correctly encodes is_cpu_op as a boolean value.


## Test Plan
1. CI pipeline passes.
2. Confirmed with Idan at NVIDIA