### PR TITLE
Update USER_GUIDE.md and Python imports to use the latest PARAM branch

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -22,8 +22,9 @@ jobs:
     - name: Install PARAM
       run: |
         git clone https://github.com/facebookresearch/param.git
-        cd param/train/compute/python/
-        git checkout c83ce8429110a86549c40fec5a01acbd9fbd54a4
+        cd param/et_replay
+        git checkout 884a1f0154a16e2c170e456f8027f2646c9108ae
+        sed -i '/param_bench/d' pyproject.toml
         pip install .
 
     - name: Test chakra_trace_link Without Arguments

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -22,8 +22,9 @@ jobs:
     - name: Install PARAM
       run: |
         git clone https://github.com/facebookresearch/param.git
-        cd param/train/compute/python/
-        git checkout c83ce8429110a86549c40fec5a01acbd9fbd54a4
+        cd param/et_replay
+        git checkout 884a1f0154a16e2c170e456f8027f2646c9108ae
+        sed -i '/param_bench/d' pyproject.toml
         pip install .
 
     - name: Install Dependencies

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -30,8 +30,9 @@ Installing PARAM is necessary for Chakra to function properly as it imports esse
 
 ```bash
 $ git clone git@github.com:facebookresearch/param.git
-$ cd param/train/compute/python/
-$ git checkout c83ce8429110a86549c40fec5a01acbd9fbd54a4
+$ cd param/et_replay
+$ git checkout 884a1f0154a16e2c170e456f8027f2646c9108ae
+$ sed -i '' '13d' pyproject.toml
 $ pip install .
 ```
 

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from param_bench.train.compute.python.tools.execution_trace import Node as PyTorchOperator
+from et_replay.lib.execution_trace import Node as PyTorchOperator
 
 
 class KinetoOperator:

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -6,14 +6,14 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Optional, Tuple
 
-from param_bench.train.compute.python.tools.execution_trace import (
+from et_replay.lib.execution_trace import (
     EXECUTION_TRACE_PROCESS_ANNOTATION,
     EXECUTION_TRACE_THREAD_ANNOTATION,
 )
-from param_bench.train.compute.python.tools.execution_trace import (
+from et_replay.lib.execution_trace import (
     Node as PyTorchOperator,
 )
-from param_bench.train.compute.python.tools.utility import (
+from et_replay.lib.utils import (
     load_execution_trace_file,
     read_dictionary_from_json_file,
 )
@@ -416,7 +416,9 @@ class TraceLinker:
 
         with ThreadPoolExecutor() as executor:
             futures = {
-                executor.submit(self.process_thread_inter_thread_order, tid, ops, kineto_tid_cpu_ops_map, threshold): tid
+                executor.submit(
+                    self.process_thread_inter_thread_order, tid, ops, kineto_tid_cpu_ops_map, threshold
+                ): tid
                 for tid, ops in kineto_tid_cpu_ops_map.items()
             }
 

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -4,11 +4,11 @@ import pytest
 from chakra.src.trace_link.kineto_operator import KinetoOperator
 from chakra.src.trace_link.trace_linker import TraceLinker
 from chakra.src.trace_link.unique_id_assigner import UniqueIdAssigner
-from param_bench.train.compute.python.tools.execution_trace import (
+from et_replay.lib.execution_trace import (
     EXECUTION_TRACE_PROCESS_ANNOTATION,
     EXECUTION_TRACE_THREAD_ANNOTATION,
 )
-from param_bench.train.compute.python.tools.execution_trace import Node as PyTorchOperator
+from et_replay.lib.execution_trace import Node as PyTorchOperator
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Update USER_GUIDE.md and Python imports to use the latest PARAM branch

## Test Plan
**1. CI pipelines pass**
**2. Ran the converters**
```
$ pip install .
Processing /Users/theo/chakra
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: protobuf==4.* in /Users/theo/chakra-venv/lib/python3.10/site-packages (from chakra==0.0.4) (4.25.3)
Requirement already satisfied: pydot in /Users/theo/chakra-venv/lib/python3.10/site-packages (from chakra==0.0.4) (2.0.0)
Requirement already satisfied: networkx in /Users/theo/chakra-venv/lib/python3.10/site-packages (from chakra==0.0.4) (3.3)
Requirement already satisfied: graphviz in /Users/theo/chakra-venv/lib/python3.10/site-packages (from chakra==0.0.4) (0.20.3)
Requirement already satisfied: pyparsing>=3 in /Users/theo/chakra-venv/lib/python3.10/site-packages (from pydot->chakra==0.0.4) (3.1.2)
Building wheels for collected packages: chakra
  Building wheel for chakra (PEP 517) ... done
  Created wheel for chakra: filename=chakra-0.0.4-py3-none-any.whl size=52262 sha256=00a97291f024555f812ee53c5f1c7cfeac15261477fa413f4a0b226612a2f4ff
  Stored in directory: /private/var/folders/z0/c9mq5j4s6n14n0_gs7nlt6mc0000gp/T/pip-ephem-wheel-cache-l9o4fb2g/wheels/fa/dc/75/2163b4163bf1e9cf3c7f1cf69fa03716fb707b8c4f5cb271e8
Successfully built chakra
Installing collected packages: chakra
  Attempting uninstall: chakra
    Found existing installation: chakra 0.0.4
    Uninstalling chakra-0.0.4:
      Successfully uninstalled chakra-0.0.4
Successfully installed chakra-0.0.4
WARNING: You are using pip version 21.2.4; however, version 24.1.1 is available.

$ python3 ci_tools/integration_tests.py --tgz_path tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz --num_ranks 8 --tolerance 0.05 --expected_times_ms 14597 14597 14968 14638 14649 14700 14677 147
35                                                                                                                  
Extracting tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz to tests/data/1.0.2-chakra.0.0.4
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_0.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_0.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json  
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_1.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_1.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json                                                               
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_3.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_3.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_2.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_2.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json   
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_4.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_4.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_5.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_5.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json                                                                                                                                                                                   
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_6.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_6.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json                                                               
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_7.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_7.json --output-file tests/data/1.0.2-
chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json                                                               
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_0.chakra --input_type PyTorch 
--log_filename /tmp/rank_0.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_1.chakra --input_type PyTorch 
--log_filename /tmp/rank_1.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_2.chakra --input_type PyTorch 
--log_filename /tmp/rank_2.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_3.chakra --input_type PyTorch 
--log_filename /tmp/rank_3.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_4.chakra --input_type PyTorch 
--log_filename /tmp/rank_4.log                                                                                                                                                                                                          
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_6.chakra --input_type PyTorch 
--log_filename /tmp/rank_6.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_5.chakra --input_type PyTorch 
--log_filename /tmp/rank_5.log                                                                                      
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_7.chakra --input_type PyTorch 
--log_filename /tmp/rank_7.log  
Validation successful for /tmp/rank_0.log: 14802300us is within the acceptable range.
Validation successful for /tmp/rank_1.log: 14785782us is within the acceptable range.
Validation successful for /tmp/rank_2.log: 15233261us is within the acceptable range.
Validation successful for /tmp/rank_3.log: 14878058us is within the acceptable range.
Validation successful for /tmp/rank_4.log: 14892945us is within the acceptable range.
Validation successful for /tmp/rank_5.log: 14993779us is within the acceptable range.
Validation successful for /tmp/rank_6.log: 14936348us is within the acceptable range.
Validation successful for /tmp/rank_7.log: 15031147us is within the acceptable range.
```
**3. Confirmed with Idan**