### PR TITLE
Add keywords for CUDA runtime ops in is_cuda_launch_op method

### DIFF
--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -95,12 +95,14 @@ class KinetoOperator:
         """
         cuda_launch_categories = {"cuda_runtime", "cuda_driver"}
         cuda_launch_operations = {
+            "cuLaunchKernel",
+            "cuLaunchKernelEx",
             "cudaLaunchKernel",
             "cudaLaunchKernelExC",
             "cudaMemcpy",
             "cudaMemcpyAsync",
-            "cudaMemcpyToSymbol",
             "cudaMemcpyFromSymbol",
+            "cudaMemcpyToSymbol",
         }
         return self.category in cuda_launch_categories and self.name in cuda_launch_operations
 

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -763,7 +763,15 @@ class TraceLinker:
             ValueError: If no CUDA runtime operator is found for the given correlation ID.
         """
         if kineto_gpu_op.correlation not in kineto_correlation_cuda_runtime_map:
-            warning_msg = f"No CUDA runtime operator found for correlation ID {kineto_gpu_op.correlation}."
+            warning_msg = (
+                f"No CUDA runtime operator found for correlation ID {kineto_gpu_op.correlation}. "
+                "This is not a common case, and there should be a corresponding CUDA runtime operator for a given GPU "
+                "kernel operator. It can be a case where CUDA runtime operators are not properly identified and added "
+                "to the map, kineto_correlation_cuda_runtime_map. Please manually check if the corresponding CUDA "
+                "runtime operator with the correlation is dropped by mistake. It is likely that it is because of "
+                "incomplete map, cuda_launch_operations, in is_cuda_launch_op. Please update the map properly to cover"
+                " all CUDA runtime launch operators."
+            )
             self.logger.warning(warning_msg)
             return None
 

--- a/tests/trace_link/test_kineto_operator.py
+++ b/tests/trace_link/test_kineto_operator.py
@@ -47,3 +47,34 @@ def test_repr_method(sample_operator_data):
         "correlation=99)"
     )
     assert repr(operator) == expected_repr
+
+@pytest.mark.parametrize("category, name, expected", [
+    ("cuda_driver", "cuLaunchKernel", True),
+    ("cuda_driver", "cuLaunchKernelEx", True),
+    ("cuda_driver", "cudaLaunchKernel", True),
+    ("cuda_driver", "cudaLaunchKernelExC", True),
+    ("cuda_runtime", "cuLaunchKernel", True),
+    ("cuda_runtime", "cuLaunchKernelEx", True),
+    ("cuda_runtime", "cudaLaunchKernel", True),
+    ("cuda_runtime", "cudaLaunchKernelExC", True),
+    ("cuda_runtime", "cudaMemcpy", True),
+    ("cuda_runtime", "cudaMemcpyAsync", True),
+    ("cuda_runtime", "cudaMemcpyFromSymbol", True),
+    ("cuda_runtime", "cudaMemcpyToSymbol", True),
+    ("cpu_op", "cudaLaunchKernel", False),
+    ("cuda_runtime", "someOtherOperation", False),
+    ("some_other_category", "cudaLaunchKernel", False)
+])
+def test_is_cuda_launch_op(category, name, expected):
+    """Test the is_cuda_launch_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": name,
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_cuda_launch_op() == expected


### PR DESCRIPTION
## Summary
Add keywords for identifying CUDA runtime operators in the is_cuda_launch_op method (cuLaunchKernel, cuLaunchKernelEx). Idan reported a bug where the output of the trace linker does not generate ncclDevKernel nodes. This issue arose because the CUDA runtime operators were not properly identified, resulting in the loss of the child ncclDevKernel nodes.

When you run the trace linker, you see a lot of messages complaining that GPU operators are dropped
```
...                                                                                                                                                                                                    
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 29853.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 29931.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d'. Orphaned GPU operator.                                                                                                                                                                                    
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 29988.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30258.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30336.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d'. Orphaned GPU operator.                                                                                                                                                                                    
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30393.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30633.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30711.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d'. Orphaned GPU operator.                                                                                                                                                                                    
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 30768.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 31008.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 31086.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d'. Orphaned GPU operator.                                                                                                                                                                                    
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 31143.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 31388.                                                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:721 [WARNING]: Missing parent CPU operator for GPU op 'triton__0d1d2d3d4d5d67d'. Orphaned GPU operator.                                                                                                                                                                             
[2024-07-01 13:46:31,162] trace_linker.py:767 [WARNING]: No CUDA runtime operator found for correlation ID 31466.                                                                                                                                                                                                             
...                                                                                   
```

## Test Plan
1. Added unit tests, and CI pipelines pass.
2. Ran the same command and could see that the warning messages are removed
```
$ chakra_trace_link --pytorch-et-file /Users/theo/Downloads/traces/megatron_et_0.json --kineto-file /Users/theo/Downloads/traces/megatron_kineto_0.json --output-file ~/megatron_0.json
[2024-07-01 13:47:35,112] trace_linker.py:118 [INFO]: Starting to load PyTorch Execution Trace.
[2024-07-01 13:47:35,293] trace_linker.py:123 [INFO]: Original ops in PyTorch ET: 9731
[2024-07-01 13:47:35,293] trace_linker.py:124 [INFO]: PyTorch Execution Trace loaded successfully.
[2024-07-01 13:47:35,294] trace_linker.py:164 [INFO]: Starting to load Kineto Trace.
[2024-07-01 13:47:35,414] trace_linker.py:198 [INFO]: Categorizing Kineto operators and calculating timing boundaries.
[2024-07-01 13:47:35,442] trace_linker.py:278 [INFO]: Calculating exclusive durations for Kineto operators in parallel.
[2024-07-01 13:47:35,442] trace_linker.py:281 [INFO]: Processing 3475 operators in thread.
[2024-07-01 13:47:35,455] trace_linker.py:281 [INFO]: Processing 6180 operators in thread.
[2024-07-01 13:47:35,516] trace_linker.py:325 [INFO]: Exclusive durations for Kineto operators calculated successfully.
[2024-07-01 13:47:35,516] trace_linker.py:177 [INFO]: Processed Kineto trace with 9655 CPU ops, 1489 CPU launcher ops, and 1617 GPU ops.
[2024-07-01 13:47:35,516] trace_linker.py:182 [INFO]: Kineto Trace loaded successfully.
[2024-07-01 13:47:35,522] trace_linker.py:415 [INFO]: Enforcing inter-thread order in Kineto traces.
[2024-07-01 13:47:35,522] trace_linker.py:445 [INFO]: Thread 18360: Identifying gaps for dependency linking with threshold 1000us.
[2024-07-01 13:47:35,527] trace_linker.py:445 [INFO]: Thread 24947: Identifying gaps for dependency linking with threshold 1000us.
[2024-07-01 13:47:35,530] trace_linker.py:521 [INFO]: Starting the process of linking PyTorch and Kineto traces.
[2024-07-01 13:47:35,530] trace_linker.py:577 [INFO]: Adding process and thread annotations to Kineto operators.
[2024-07-01 13:47:35,535] trace_linker.py:641 [INFO]: Mapping PyTorch ET nodes to Kineto operators.
[2024-07-01 13:47:35,539] trace_linker.py:656 [WARNING]: Number of PyTorch operators (9731) is larger than the number of Kineto operators (9673). Expected PyTorch ops (CPU only) to be fewer than Kineto ops (CPU and GPU). Logging this rare but possible scenario.
[2024-07-01 13:47:35,546] trace_linker.py:679 [INFO]: Completed mapping of PyTorch operators to Kineto operators.
[2024-07-01 13:47:35,547] trace_linker.py:926 [INFO]: Constructing ET+ data.
[2024-07-01 13:47:35,803] trace_linker.py:557 [INFO]: Traces have been successfully linked.
[2024-07-01 13:47:35,804] trace_linker.py:1049 [INFO]: Starting to dump ET+ data to /Users/theo/megatron_0.json.
[2024-07-01 13:47:36,433] trace_linker.py:1061 [INFO]: ET+ data dumped to /Users/theo/megatron_0.json.
```
3. Confirmed with Idan.