### PR TITLE
Refactor KinetoOperator and TraceLinker for code quality and test coverage

### DIFF
--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -136,9 +136,18 @@ class KinetoOperator:
         gpu_categories = {"kernel", "gpu_memcpy"}
         return self.category in gpu_categories
 
-    def is_arrow_op(self) -> bool:
+    def is_ac2g_op(self) -> bool:
         """
         Check if the operator is categorized as 'ac2g', which stands for arrows from CPU to GPU.
+
+        Excerpt from https://pytorch.org/docs/stable/torch.compiler_profiling_torch_compile.html
+        ```
+            Every kernel on the GPU occurs after being launched by code running on the CPU. The profiler can draw
+            connections (i.e. "flows") between the GPU and CPU events to show which CPU event launched a GPU kernel.
+            This is particularly helpful because, with a few exceptions, GPU kernels are launched asynchronously.
+
+            To view a flow connection, click on a GPU kernel and click "ac2g".
+        ````
 
         Returns
             bool: True if the operator is an 'ac2g' type, otherwise False.

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -86,14 +86,32 @@ class KinetoOperator:
             return True
         return False
 
-    def is_cuda_launch_op(self) -> bool:
+    def is_cuda_runtime_op(self) -> bool:
+        """
+        Determine whether the operator is a CUDA runtime operator.
+
+        Returns
+            bool: True if it's a CUDA runtime operator, otherwise False.
+        """
+        return self.category == "cuda_runtime"
+
+    def is_cuda_driver_op(self) -> bool:
+        """
+        Determine whether the operator is a CUDA driver operator.
+
+        Returns
+            bool: True if it's a CUDA driver operator, otherwise False.
+        """
+        return self.category == "cuda_driver"
+
+    def is_kernel_launch_op(self) -> bool:
         """
         Determine whether the operator is a kernel-launching CUDA runtime operator.
 
         Returns
             bool: True if it's a launch operation, otherwise False.
         """
-        cuda_launch_categories = {"cuda_runtime", "cuda_driver"}
+        cuda_launch_categories = self.is_cuda_runtime_op() or self.is_cuda_driver_op()
         cuda_launch_operations = {
             "cuLaunchKernel",
             "cuLaunchKernelEx",
@@ -105,7 +123,7 @@ class KinetoOperator:
             "cudaMemcpyToSymbol",
             "cudaLaunchCooperativeKernel",
         }
-        return self.category in cuda_launch_categories and self.name in cuda_launch_operations
+        return cuda_launch_categories and self.name in cuda_launch_operations
 
     def is_gpu_op(self) -> bool:
         """

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -13,7 +13,8 @@ class KinetoOperator:
         name (str): Name of the operator.
         phase (Optional[str]): Execution phase of the operator.
         inclusive_dur (int): Total duration of the operator, including its children.
-        exclusive_dur (int): Duration of the operator execution alone. Corresponds to the self time field in chrome://tracing.
+        exclusive_dur (int): Duration of the operator execution alone. Corresponds to the self time field in
+            chrome://tracing.
         timestamp (int): Start time of the operator in microseconds.
         external_id (int): An external identifier associated with the operator.
         ev_idx (int): Event index of the operator.

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -105,6 +105,24 @@ class KinetoOperator:
         """
         return self.category == "cuda_driver"
 
+    def is_ac2g_op(self) -> bool:
+        """
+        Check if the operator is categorized as 'ac2g', which stands for arrows from CPU to GPU.
+
+        Excerpt from https://pytorch.org/docs/stable/torch.compiler_profiling_torch_compile.html
+        ```
+            Every kernel on the GPU occurs after being launched by code running on the CPU. The profiler can draw
+            connections (i.e. "flows") between the GPU and CPU events to show which CPU event launched a GPU kernel.
+            This is particularly helpful because, with a few exceptions, GPU kernels are launched asynchronously.
+
+            To view a flow connection, click on a GPU kernel and click "ac2g".
+        ````
+
+        Returns
+            bool: True if the operator is an 'ac2g' type, otherwise False.
+        """
+        return self.category == "ac2g"
+
     def is_kernel_launch_op(self) -> bool:
         """
         Determine whether the operator is a kernel-launching CUDA runtime operator.
@@ -135,21 +153,3 @@ class KinetoOperator:
         """
         gpu_categories = {"kernel", "gpu_memcpy"}
         return self.category in gpu_categories
-
-    def is_ac2g_op(self) -> bool:
-        """
-        Check if the operator is categorized as 'ac2g', which stands for arrows from CPU to GPU.
-
-        Excerpt from https://pytorch.org/docs/stable/torch.compiler_profiling_torch_compile.html
-        ```
-            Every kernel on the GPU occurs after being launched by code running on the CPU. The profiler can draw
-            connections (i.e. "flows") between the GPU and CPU events to show which CPU event launched a GPU kernel.
-            This is particularly helpful because, with a few exceptions, GPU kernels are launched asynchronously.
-
-            To view a flow connection, click on a GPU kernel and click "ac2g".
-        ````
-
-        Returns
-            bool: True if the operator is an 'ac2g' type, otherwise False.
-        """
-        return self.category == "ac2g"

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -224,7 +224,7 @@ class TraceLinker:
                 kineto_gpu_ops.append(op)
                 logging.debug(f"Added GPU op: {op.name}")
 
-            elif op.is_arrow_op():
+            elif op.is_ac2g_op():  # arrow from CPU to GPU
                 assert (op.phase == "s") or (op.phase == "f")
                 if op.id is None:
                     error_msg = (

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -211,7 +211,7 @@ class TraceLinker:
                 kineto_tid_cpu_ops_map.setdefault(op.tid, []).append(op)
                 logging.debug(f"Added CPU or user annotation op: {op.name}")
 
-            elif op.is_cuda_launch_op():
+            elif op.is_kernel_launch_op():
                 kineto_id_cuda_launch_op_map[op.external_id] = op
                 if op.correlation in kineto_correlation_cuda_runtime_map:
                     raise ValueError(
@@ -795,8 +795,8 @@ class TraceLinker:
                 "kernel operator. It can be a case where CUDA runtime operators are not properly identified and added "
                 "to the map, kineto_correlation_cuda_runtime_map. Please manually check if the corresponding CUDA "
                 "runtime operator with the correlation is dropped by mistake. It is likely that it is because of "
-                "incomplete map, cuda_launch_operations, in is_cuda_launch_op. Please update the map properly to cover"
-                " all CUDA runtime launch operators."
+                "incomplete map, cuda_launch_operations, in is_kernel_launch_op. Please update the map properly to "
+                "cover all CUDA runtime launch operators."
             )
             logging.warning(warning_msg)
             return None

--- a/tests/trace_link/test_kineto_operator.py
+++ b/tests/trace_link/test_kineto_operator.py
@@ -71,8 +71,8 @@ def test_repr_method(sample_operator_data):
         ("some_other_category", "cudaLaunchKernel", False),
     ],
 )
-def test_is_cuda_launch_op(category, name, expected):
-    """Test the is_cuda_launch_op method with various inputs."""
+def test_is_kernel_launch_op(category, name, expected):
+    """Test the is_kernel_launch_op method with various inputs."""
     operator_data = {
         "cat": category,
         "name": name,
@@ -83,4 +83,4 @@ def test_is_cuda_launch_op(category, name, expected):
         "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
     }
     operator = KinetoOperator(operator_data)
-    assert operator.is_cuda_launch_op() == expected
+    assert operator.is_kernel_launch_op() == expected

--- a/tests/trace_link/test_kineto_operator.py
+++ b/tests/trace_link/test_kineto_operator.py
@@ -50,6 +50,103 @@ def test_repr_method(sample_operator_data):
 
 
 @pytest.mark.parametrize(
+    "category, expected",
+    [
+        ("cpu_op", True),
+        ("user_annotation", True),
+        ("ProfilerStep", False),
+        ("cuda_runtime", False),
+        ("cuda_driver", False),
+    ],
+)
+def test_is_cpu_op(category, expected):
+    """Test the is_cpu_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": "someOperation",
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_cpu_op() == expected
+
+
+@pytest.mark.parametrize(
+    "category, expected",
+    [
+        ("cuda_runtime", True),
+        ("kernel", False),
+        ("cuda_driver", False),
+        ("cpu_op", False),
+    ],
+)
+def test_is_cuda_runtime_op(category, expected):
+    """Test the is_cuda_runtime_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": "someOperation",
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_cuda_runtime_op() == expected
+
+
+@pytest.mark.parametrize(
+    "category, expected",
+    [
+        ("cuda_driver", True),
+        ("kernel", False),
+        ("cuda_runtime", False),
+        ("cpu_op", False),
+    ],
+)
+def test_is_cuda_driver_op(category, expected):
+    """Test the is_cuda_driver_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": "someOperation",
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_cuda_driver_op() == expected
+
+
+@pytest.mark.parametrize(
+    "category, expected",
+    [
+        ("ac2g", True),
+        ("kernel", False),
+        ("cuda_runtime", False),
+        ("cpu_op", False),
+    ],
+)
+def test_is_ac2g_op(category, expected):
+    """Test the is_ac2g_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": "someOperation",
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_ac2g_op() == expected
+
+
+@pytest.mark.parametrize(
     "category, name, expected",
     [
         ("cuda_driver", "cuLaunchKernel", True),
@@ -84,3 +181,27 @@ def test_is_kernel_launch_op(category, name, expected):
     }
     operator = KinetoOperator(operator_data)
     assert operator.is_kernel_launch_op() == expected
+
+
+@pytest.mark.parametrize(
+    "category, expected",
+    [
+        ("kernel", True),
+        ("gpu_memcpy", True),
+        ("cuda_runtime", False),
+        ("cpu_op", False),
+    ],
+)
+def test_is_gpu_op(category, expected):
+    """Test the is_gpu_op method with various inputs."""
+    operator_data = {
+        "cat": category,
+        "name": "someOperation",
+        "ph": "X",
+        "dur": 100,
+        "ts": 1590000000,
+        "tid": 1234,
+        "args": {"External id": "123", "Ev Idx": "456", "stream": 7, "Record function id": 12, "correlation": 99},
+    }
+    operator = KinetoOperator(operator_data)
+    assert operator.is_gpu_op() == expected

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -20,6 +20,44 @@ def test_initialization(trace_linker):
     assert isinstance(trace_linker.id_assigner, UniqueIdAssigner)
 
 
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.construct_et_plus_data")
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.add_thread_and_process_annotations")
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.map_pytorch_to_kineto_ops")
+def test_link_traces(mock_map_ops, mock_add_annotations, mock_construct_et_plus, trace_linker):
+    mock_add_annotations.return_value = ([], [], [])
+    mock_map_ops.return_value = ({}, {}, {}, {}, {})
+    mock_construct_et_plus.return_value = {}
+
+    pytorch_ops = [MagicMock(spec=PyTorchOperator)]
+    kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
+    sorted_kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
+    sorted_kineto_cpu_op_ts = [100]
+    kineto_correlation_cuda_runtime_map = {1: MagicMock(spec=KinetoOperator)}
+    kineto_rf_id_to_kineto_op_map = {1: MagicMock(spec=KinetoOperator)}
+    kineto_gpu_ops = [MagicMock(spec=KinetoOperator)]
+    kineto_thread_info = {1: (100, 200)}
+    kineto_process_start_time = 50
+    kineto_process_end_time = 300
+
+    trace_linker.link_traces(
+        "pytorch_et_file",
+        pytorch_ops,
+        kineto_cpu_ops,
+        sorted_kineto_cpu_ops,
+        sorted_kineto_cpu_op_ts,
+        kineto_correlation_cuda_runtime_map,
+        kineto_rf_id_to_kineto_op_map,
+        kineto_gpu_ops,
+        kineto_thread_info,
+        kineto_process_start_time,
+        kineto_process_end_time,
+    )
+
+    mock_add_annotations.assert_called_once()
+    mock_map_ops.assert_called_once()
+    mock_construct_et_plus.assert_called_once()
+
+
 @patch("chakra.src.trace_link.trace_linker.TraceLinker.load_pytorch_et")
 @patch("chakra.src.trace_link.trace_linker.TraceLinker.load_kineto_trace")
 def test_load_traces(mock_load_kineto_trace, mock_load_pytorch_et, trace_linker):
@@ -29,44 +67,50 @@ def test_load_traces(mock_load_kineto_trace, mock_load_pytorch_et, trace_linker)
     mock_load_kineto_trace.assert_called_once()
 
 
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.load_traces")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.update_kineto_data")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.enforce_inter_thread_order")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.link_traces")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.dump_pytorch_execution_trace_plus")
-def test_link(mock_dump, mock_link_traces, mock_enforce_order, mock_update_data, mock_load_traces, trace_linker):
-    mock_load_traces.return_value = ([], {})
-    mock_update_data.return_value = ([], {}, {}, [], {}, {}, 0, 0, {}, {}, [], [])
-    mock_enforce_order.return_value = {}
+def test_extract_pytorch_ops(trace_linker):
+    mock_root_node = MagicMock(spec=PyTorchOperator)
+    mock_child_node = MagicMock(spec=PyTorchOperator)
 
-    trace_linker.link("pytorch_et_file", "kineto_file", "output_file")
+    mock_root_node.children = [mock_child_node]
+    mock_child_node.children = []
 
-    mock_load_traces.assert_called_once()
-    mock_update_data.assert_called_once()
-    mock_enforce_order.assert_called_once()
-    mock_link_traces.assert_called_once()
-    mock_dump.assert_called_once()
+    mock_root_node.id = 1
+    mock_child_node.id = 2
+
+    result = trace_linker.extract_pytorch_ops(mock_root_node)
+    assert len(result) == 2
+    assert result[0].id == 1
+    assert result[1].id == 2
 
 
-def test_construct_kineto_data_structures(trace_linker):
-    mock_kineto_op1 = MagicMock(spec=KinetoOperator)
-    mock_kineto_op1.is_cpu_op.return_value = True
-    mock_kineto_op1.timestamp = 100
-    mock_kineto_op1.inclusive_dur = 50
-    mock_kineto_op1.tid = 1
-    mock_kineto_op1.name = "op1"
-    mock_kineto_op1.rf_id = 1
+@pytest.mark.parametrize(
+    "kineto_ops, expected_exclusive_durs",
+    [
+        (
+            [
+                {"ts": 100, "dur": 10, "inclusive_dur": 10},
+                {"ts": 105, "dur": 3, "inclusive_dur": 3},
+                {"ts": 108, "dur": 1, "inclusive_dur": 1},
+            ],
+            [6, 3, 1],  # Expected exclusive durations
+        ),
+        (
+            [
+                {"ts": 100, "dur": 20, "inclusive_dur": 20},
+                {"ts": 105, "dur": 5, "inclusive_dur": 5},
+                {"ts": 110, "dur": 5, "inclusive_dur": 5},
+            ],
+            [10, 5, 5],  # Expected exclusive durations
+        ),
+    ],
+)
+def test_calculate_exclusive_dur(trace_linker, kineto_ops, expected_exclusive_durs):
+    kineto_tid_cpu_ops_map = {1: [KinetoOperator(op) for op in kineto_ops]}
 
-    mock_kineto_op2 = MagicMock(spec=KinetoOperator)
-    mock_kineto_op2.is_cpu_op.return_value = True
-    mock_kineto_op2.timestamp = 200
-    mock_kineto_op2.inclusive_dur = 50
-    mock_kineto_op2.tid = 1
-    mock_kineto_op2.name = "op2"
-    mock_kineto_op2.rf_id = 2
+    trace_linker.calculate_exclusive_dur(kineto_tid_cpu_ops_map)
 
-    kineto_data = trace_linker.construct_kineto_data_structures([mock_kineto_op1, mock_kineto_op2])
-    assert kineto_data["kineto_tid_cpu_ops_map"][1] == [mock_kineto_op1, mock_kineto_op2]
+    for i, op in enumerate(kineto_tid_cpu_ops_map[1]):
+        assert op.exclusive_dur == expected_exclusive_durs[i]
 
 
 @pytest.mark.parametrize(
@@ -82,6 +126,38 @@ def test_construct_kineto_data_structures(trace_linker):
 def test_merge_overlapping_intervals(intervals, expected_result):
     result = TraceLinker.merge_overlapping_intervals(intervals)
     assert result == expected_result
+
+
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.find_last_cpu_node_before_timestamp")
+def test_process_thread_inter_thread_order(mock_find_last, trace_linker):
+    mock_op1 = MagicMock(spec=KinetoOperator)
+    mock_op1.timestamp = 100
+    mock_op1.inclusive_dur = 50
+    mock_op1.tid = 1
+    mock_op1.name = "op1"
+    mock_op1.rf_id = 1
+
+    mock_op2 = MagicMock(spec=KinetoOperator)
+    mock_op2.timestamp = 200
+    mock_op2.inclusive_dur = 50
+    mock_op2.tid = 1
+    mock_op2.name = "op2"
+    mock_op2.rf_id = 2
+
+    ops_by_tid = {1: [mock_op1, mock_op2]}
+    trace_linker.process_thread_inter_thread_order(1, [mock_op1, mock_op2], ops_by_tid, 1000)
+
+    mock_find_last.assert_called()
+
+
+@patch("concurrent.futures.Future.result")
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.process_thread_inter_thread_order")
+def test_enforce_inter_thread_order_exception(mock_process_thread, mock_future_result, trace_linker):
+    mock_future_result.side_effect = Exception("Test Exception")
+    kineto_tid_cpu_ops_map = {1: [MagicMock(spec=KinetoOperator)]}
+
+    with pytest.raises(Exception, match="Test Exception"):
+        trace_linker.enforce_inter_thread_order(kineto_tid_cpu_ops_map)
 
 
 @pytest.mark.parametrize(
@@ -142,6 +218,198 @@ def test_find_last_cpu_node_before_timestamp(ops_by_tid, exclude_tid, timestamp,
     assert result == expected_result
 
 
+def test_add_thread_and_process_annotations(trace_linker):
+    kineto_cpu_ops = []
+    sorted_kineto_cpu_ops = []
+    sorted_kineto_cpu_op_ts = []
+    kineto_thread_info = {1: (100, 200), 2: (150, 250)}
+    kineto_process_start_time = 50
+    kineto_process_end_time = 300
+
+    kineto_cpu_ops, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts = trace_linker.add_thread_and_process_annotations(
+        kineto_cpu_ops,
+        sorted_kineto_cpu_ops,
+        sorted_kineto_cpu_op_ts,
+        kineto_thread_info,
+        kineto_process_start_time,
+        kineto_process_end_time,
+    )
+
+    assert len(kineto_cpu_ops) == 3
+    assert kineto_cpu_ops[0].name == EXECUTION_TRACE_PROCESS_ANNOTATION
+    assert kineto_cpu_ops[1].name == EXECUTION_TRACE_THREAD_ANNOTATION
+    assert kineto_cpu_ops[2].name == EXECUTION_TRACE_THREAD_ANNOTATION
+
+    assert len(sorted_kineto_cpu_ops) == 3
+    assert sorted_kineto_cpu_ops[0].timestamp == kineto_cpu_ops[0].timestamp
+    assert sorted_kineto_cpu_ops[1].timestamp == kineto_cpu_ops[1].timestamp
+    assert sorted_kineto_cpu_ops[2].timestamp == kineto_cpu_ops[2].timestamp
+
+    assert len(sorted_kineto_cpu_op_ts) == 3
+    assert sorted_kineto_cpu_op_ts[0] == kineto_cpu_ops[0].timestamp
+    assert sorted_kineto_cpu_op_ts[1] == kineto_cpu_ops[1].timestamp
+    assert sorted_kineto_cpu_op_ts[2] == kineto_cpu_ops[2].timestamp
+
+
+def test_group_gpu_ops_by_cpu_launchers(trace_linker):
+    kineto_gpu_op1 = MagicMock(spec=KinetoOperator)
+    kineto_gpu_op1.correlation = 123
+    kineto_gpu_op1.name = "gpu_op1"
+    kineto_gpu_op1.timestamp = 150
+    kineto_gpu_op1.tid = 1
+
+    kineto_gpu_op2 = MagicMock(spec=KinetoOperator)
+    kineto_gpu_op2.correlation = 456
+    kineto_gpu_op2.name = "gpu_op2"
+    kineto_gpu_op2.timestamp = 250
+    kineto_gpu_op2.tid = 2
+
+    kineto_runtime_op1 = MagicMock(spec=KinetoOperator)
+    kineto_runtime_op1.ev_idx = "cpu_op1"
+    kineto_runtime_op1.timestamp = 100
+    kineto_runtime_op1.tid = 1
+    kineto_runtime_op1.name = "runtime_op1"
+    kineto_runtime_op1.correlation = 123
+
+    kineto_runtime_op2 = MagicMock(spec=KinetoOperator)
+    kineto_runtime_op2.ev_idx = "cpu_op2"
+    kineto_runtime_op2.timestamp = 200
+    kineto_runtime_op2.tid = 2
+    kineto_runtime_op2.name = "runtime_op2"
+    kineto_runtime_op2.correlation = 456
+
+    kineto_correlation_cuda_runtime_map = {123: kineto_runtime_op1, 456: kineto_runtime_op2}
+    sorted_kineto_cpu_ops = [kineto_runtime_op1, kineto_runtime_op2]
+    sorted_kineto_cpu_op_ts = [kineto_runtime_op1.timestamp, kineto_runtime_op2.timestamp]
+
+    with patch.object(trace_linker, "find_parent_cpu_op", side_effect=[kineto_runtime_op1, kineto_runtime_op2]):
+        result = trace_linker.group_gpu_ops_by_cpu_launchers(
+            [kineto_gpu_op1, kineto_gpu_op2],
+            kineto_correlation_cuda_runtime_map,
+            sorted_kineto_cpu_ops,
+            sorted_kineto_cpu_op_ts,
+        )
+
+    assert result == {"cpu_op1": [kineto_gpu_op1], "cpu_op2": [kineto_gpu_op2]}
+
+
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.find_closest_op")
+def test_find_parent_cpu_op(mock_find_closest_op, trace_linker):
+    kineto_gpu_op = MagicMock(spec=KinetoOperator)
+    kineto_gpu_op.correlation = 123
+    kineto_gpu_op.name = "gpu_op"
+
+    kineto_runtime_op = MagicMock(spec=KinetoOperator)
+    kineto_runtime_op.timestamp = 100
+    kineto_runtime_op.tid = 1
+    kineto_runtime_op.name = "runtime_op"
+
+    kineto_correlation_cuda_runtime_map = {123: kineto_runtime_op}
+
+    mock_find_closest_op.return_value = kineto_runtime_op
+
+    sorted_kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
+    sorted_kineto_cpu_op_ts = [100]
+
+    result = trace_linker.find_parent_cpu_op(
+        kineto_gpu_op, kineto_correlation_cuda_runtime_map, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts
+    )
+
+    assert result == kineto_runtime_op
+    mock_find_closest_op.assert_called_once_with(
+        kineto_gpu_op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts, kineto_runtime_op.timestamp
+    )
+
+
+@pytest.mark.parametrize(
+    "pytorch_op, kineto_op, expected_linked_gpu_ops, expected_inclusive_dur, expected_exclusive_dur, "
+    "expected_timestamp, expected_inter_thread_dep",
+    [
+        (
+            MagicMock(spec=PyTorchOperator, id=1),
+            MagicMock(
+                spec=KinetoOperator, ev_idx="1", inclusive_dur=100, exclusive_dur=50, timestamp=123456, pytorch_op=None
+            ),
+            [MagicMock(spec=KinetoOperator)],
+            100,
+            50,
+            123456,
+            None,
+        ),
+        (
+            MagicMock(spec=PyTorchOperator, id=2),
+            MagicMock(
+                spec=KinetoOperator, ev_idx="2", inclusive_dur=200, exclusive_dur=150, timestamp=223456, pytorch_op=None
+            ),
+            [MagicMock(spec=KinetoOperator), MagicMock(spec=KinetoOperator)],
+            200,
+            150,
+            223456,
+            42,
+        ),
+    ],
+)
+@patch.object(TraceLinker, "get_inter_thread_dep")
+@patch.object(TraceLinker, "link_gpu_ops")
+def test_link_ops(
+    mock_link_gpu_ops,
+    mock_get_inter_thread_dep,
+    trace_linker,
+    pytorch_op,
+    kineto_op,
+    expected_linked_gpu_ops,
+    expected_inclusive_dur,
+    expected_exclusive_dur,
+    expected_timestamp,
+    expected_inter_thread_dep,
+):
+    mock_get_inter_thread_dep.return_value = expected_inter_thread_dep
+
+    cpu_ev_idx_to_gpu_ops_map = {kineto_op.ev_idx: expected_linked_gpu_ops}
+    kineto_rf_id_to_kineto_op_map = {1: MagicMock(spec=KinetoOperator, pytorch_op=MagicMock(id=42))}
+
+    result = trace_linker.link_ops(
+        pytorch_op,
+        kineto_op,
+        cpu_ev_idx_to_gpu_ops_map,
+        kineto_rf_id_to_kineto_op_map,
+    )
+
+    assert result == (
+        expected_linked_gpu_ops,
+        expected_inclusive_dur,
+        expected_exclusive_dur,
+        expected_timestamp,
+        expected_inter_thread_dep,
+    )
+    mock_link_gpu_ops.assert_called_once_with(pytorch_op, expected_linked_gpu_ops)
+
+
+def test_link_ops_with_no_gpu_ops(trace_linker):
+    pytorch_op = MagicMock(spec=PyTorchOperator, id=1)
+    kineto_op = MagicMock(
+        spec=KinetoOperator,
+        ev_idx="1",
+        inclusive_dur=100,
+        exclusive_dur=50,
+        timestamp=123456,
+        pytorch_op=None,
+        inter_thread_dep=None,
+    )
+
+    cpu_ev_idx_to_gpu_ops_map = {}
+    kineto_rf_id_to_kineto_op_map = {}
+
+    result = trace_linker.link_ops(
+        pytorch_op,
+        kineto_op,
+        cpu_ev_idx_to_gpu_ops_map,
+        kineto_rf_id_to_kineto_op_map,
+    )
+
+    assert result == ([], 100, 50, 123456, None)
+
+
 def test_get_inter_thread_dep(trace_linker):
     kineto_op = MagicMock(spec=KinetoOperator)
     kineto_op.inter_thread_dep = 1
@@ -177,9 +445,30 @@ def test_link_gpu_ops(trace_linker):
     # Call the method
     trace_linker.link_gpu_ops(pytorch_op, kineto_gpu_ops)
 
-    # Assert that the parent_pytorch_op_id is set correctly
-    for gpu_op in kineto_gpu_ops:
-        assert gpu_op.parent_pytorch_op_id == pytorch_op.id
+
+@patch("chakra.src.trace_link.trace_linker.TraceLinker.process_op_and_dependents")
+@patch("builtins.open", new_callable=MagicMock)
+@patch("json.load")
+def test_construct_et_plus_data(mock_json_load, mock_open, mock_process_op_and_dependents, trace_linker):
+    mock_json_load.return_value = {"nodes": [{"id": 1}, {"id": 2}]}
+    mock_process_op_and_dependents.side_effect = lambda x, *args: [{"id": x["id"] + 2}]
+
+    pytorch_op_id_to_kineto_ops_map = {1: [], 2: []}
+    pytorch_op_id_to_inclusive_dur_map = {1: 100, 2: 200}
+    pytorch_op_id_to_exclusive_dur_map = {1: 50, 2: 150}
+    pytorch_op_id_to_timestamp_map = {1: 1000, 2: 2000}
+    pytorch_op_id_to_inter_thread_dep_map = {1: None, 2: None}
+
+    pytorch_et_plus_data = trace_linker.construct_et_plus_data(
+        "path/to/pytorch_et_file",
+        pytorch_op_id_to_kineto_ops_map,
+        pytorch_op_id_to_inclusive_dur_map,
+        pytorch_op_id_to_exclusive_dur_map,
+        pytorch_op_id_to_timestamp_map,
+        pytorch_op_id_to_inter_thread_dep_map,
+    )
+
+    assert pytorch_et_plus_data["nodes"] == [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
 
 
 @pytest.mark.parametrize(
@@ -270,31 +559,6 @@ def test_process_dependent_gpu_ops(trace_linker, orig_op_id, cpu_op, kineto_gpu_
         assert updated_gpu_op["stream"] == kineto_gpu_op_objects[i].stream
 
 
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.process_op_and_dependents")
-@patch("builtins.open", new_callable=MagicMock)
-@patch("json.load")
-def test_construct_et_plus_data(mock_json_load, mock_open, mock_process_op_and_dependents, trace_linker):
-    mock_json_load.return_value = {"nodes": [{"id": 1}, {"id": 2}]}
-    mock_process_op_and_dependents.side_effect = lambda x, *args: [{"id": x["id"] + 2}]
-
-    pytorch_op_id_to_kineto_ops_map = {1: [], 2: []}
-    pytorch_op_id_to_inclusive_dur_map = {1: 100, 2: 200}
-    pytorch_op_id_to_exclusive_dur_map = {1: 50, 2: 150}
-    pytorch_op_id_to_timestamp_map = {1: 1000, 2: 2000}
-    pytorch_op_id_to_inter_thread_dep_map = {1: None, 2: None}
-
-    pytorch_et_plus_data = trace_linker.construct_et_plus_data(
-        "path/to/pytorch_et_file",
-        pytorch_op_id_to_kineto_ops_map,
-        pytorch_op_id_to_inclusive_dur_map,
-        pytorch_op_id_to_exclusive_dur_map,
-        pytorch_op_id_to_timestamp_map,
-        pytorch_op_id_to_inter_thread_dep_map,
-    )
-
-    assert pytorch_et_plus_data["nodes"] == [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
-
-
 @patch("builtins.open", new_callable=MagicMock)
 @patch("json.dump")
 def test_dump_pytorch_execution_trace_plus(mock_json_dump, mock_open, trace_linker):
@@ -307,205 +571,3 @@ def test_dump_pytorch_execution_trace_plus(mock_json_dump, mock_open, trace_link
     mock_json_dump.assert_called_once_with(
         {"nodes": [{"id": 1}, {"id": 2}]}, mock_open.return_value.__enter__(), indent=4
     )
-
-
-def test_add_thread_and_process_annotations(trace_linker):
-    kineto_cpu_ops = []
-    sorted_kineto_cpu_ops = []
-    sorted_kineto_cpu_op_ts = []
-    kineto_thread_info = {1: (100, 200), 2: (150, 250)}
-    kineto_process_start_time = 50
-    kineto_process_end_time = 300
-
-    kineto_cpu_ops, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts = trace_linker.add_thread_and_process_annotations(
-        kineto_cpu_ops,
-        sorted_kineto_cpu_ops,
-        sorted_kineto_cpu_op_ts,
-        kineto_thread_info,
-        kineto_process_start_time,
-        kineto_process_end_time,
-    )
-
-    assert len(kineto_cpu_ops) == 3
-    assert kineto_cpu_ops[0].name == EXECUTION_TRACE_PROCESS_ANNOTATION
-    assert kineto_cpu_ops[1].name == EXECUTION_TRACE_THREAD_ANNOTATION
-    assert kineto_cpu_ops[2].name == EXECUTION_TRACE_THREAD_ANNOTATION
-
-    assert len(sorted_kineto_cpu_ops) == 3
-    assert sorted_kineto_cpu_ops[0].timestamp == kineto_cpu_ops[0].timestamp
-    assert sorted_kineto_cpu_ops[1].timestamp == kineto_cpu_ops[1].timestamp
-    assert sorted_kineto_cpu_ops[2].timestamp == kineto_cpu_ops[2].timestamp
-
-    assert len(sorted_kineto_cpu_op_ts) == 3
-    assert sorted_kineto_cpu_op_ts[0] == kineto_cpu_ops[0].timestamp
-    assert sorted_kineto_cpu_op_ts[1] == kineto_cpu_ops[1].timestamp
-    assert sorted_kineto_cpu_op_ts[2] == kineto_cpu_ops[2].timestamp
-
-
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.find_closest_op")
-def test_find_parent_cpu_op(mock_find_closest_op, trace_linker):
-    kineto_gpu_op = MagicMock(spec=KinetoOperator)
-    kineto_gpu_op.correlation = 123
-    kineto_gpu_op.name = "gpu_op"
-
-    kineto_runtime_op = MagicMock(spec=KinetoOperator)
-    kineto_runtime_op.timestamp = 100
-    kineto_runtime_op.tid = 1
-    kineto_runtime_op.name = "runtime_op"
-
-    kineto_correlation_cuda_runtime_map = {123: kineto_runtime_op}
-
-    mock_find_closest_op.return_value = kineto_runtime_op
-
-    sorted_kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
-    sorted_kineto_cpu_op_ts = [100]
-
-    result = trace_linker.find_parent_cpu_op(
-        kineto_gpu_op, kineto_correlation_cuda_runtime_map, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts
-    )
-
-    assert result == kineto_runtime_op
-    mock_find_closest_op.assert_called_once_with(
-        kineto_gpu_op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts, kineto_runtime_op.timestamp
-    )
-
-
-def test_group_gpu_ops_by_cpu_launchers(trace_linker):
-    kineto_gpu_op1 = MagicMock(spec=KinetoOperator)
-    kineto_gpu_op1.correlation = 123
-    kineto_gpu_op1.name = "gpu_op1"
-    kineto_gpu_op1.timestamp = 150
-    kineto_gpu_op1.tid = 1
-
-    kineto_gpu_op2 = MagicMock(spec=KinetoOperator)
-    kineto_gpu_op2.correlation = 456
-    kineto_gpu_op2.name = "gpu_op2"
-    kineto_gpu_op2.timestamp = 250
-    kineto_gpu_op2.tid = 2
-
-    kineto_runtime_op1 = MagicMock(spec=KinetoOperator)
-    kineto_runtime_op1.ev_idx = "cpu_op1"
-    kineto_runtime_op1.timestamp = 100
-    kineto_runtime_op1.tid = 1
-    kineto_runtime_op1.name = "runtime_op1"
-    kineto_runtime_op1.correlation = 123
-
-    kineto_runtime_op2 = MagicMock(spec=KinetoOperator)
-    kineto_runtime_op2.ev_idx = "cpu_op2"
-    kineto_runtime_op2.timestamp = 200
-    kineto_runtime_op2.tid = 2
-    kineto_runtime_op2.name = "runtime_op2"
-    kineto_runtime_op2.correlation = 456
-
-    kineto_correlation_cuda_runtime_map = {123: kineto_runtime_op1, 456: kineto_runtime_op2}
-    sorted_kineto_cpu_ops = [kineto_runtime_op1, kineto_runtime_op2]
-    sorted_kineto_cpu_op_ts = [kineto_runtime_op1.timestamp, kineto_runtime_op2.timestamp]
-
-    with patch.object(trace_linker, "find_parent_cpu_op", side_effect=[kineto_runtime_op1, kineto_runtime_op2]):
-        result = trace_linker.group_gpu_ops_by_cpu_launchers(
-            [kineto_gpu_op1, kineto_gpu_op2],
-            kineto_correlation_cuda_runtime_map,
-            sorted_kineto_cpu_ops,
-            sorted_kineto_cpu_op_ts,
-        )
-
-    assert result == {"cpu_op1": [kineto_gpu_op1], "cpu_op2": [kineto_gpu_op2]}
-
-
-def test_calculate_exclusive_dur(trace_linker):
-    kineto_op1 = KinetoOperator({"ts": 100, "dur": 10, "inclusive_dur": 10})
-    kineto_op2 = KinetoOperator({"ts": 105, "dur": 3, "inclusive_dur": 3})
-    kineto_op3 = KinetoOperator({"ts": 108, "dur": 1, "inclusive_dur": 1})
-    kineto_tid_cpu_ops_map = {1: [kineto_op1, kineto_op2, kineto_op3]}
-
-    trace_linker.calculate_exclusive_dur(kineto_tid_cpu_ops_map)
-
-    assert kineto_op1.exclusive_dur == 6  # 10 - (3 + 1)
-    assert kineto_op2.exclusive_dur == 3
-    assert kineto_op3.exclusive_dur == 1
-
-
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.find_last_cpu_node_before_timestamp")
-def test_process_thread_inter_thread_order(mock_find_last, trace_linker):
-    mock_op1 = MagicMock(spec=KinetoOperator)
-    mock_op1.timestamp = 100
-    mock_op1.inclusive_dur = 50
-    mock_op1.tid = 1
-    mock_op1.name = "op1"
-    mock_op1.rf_id = 1
-
-    mock_op2 = MagicMock(spec=KinetoOperator)
-    mock_op2.timestamp = 200
-    mock_op2.inclusive_dur = 50
-    mock_op2.tid = 1
-    mock_op2.name = "op2"
-    mock_op2.rf_id = 2
-
-    ops_by_tid = {1: [mock_op1, mock_op2]}
-    trace_linker.process_thread_inter_thread_order(1, [mock_op1, mock_op2], ops_by_tid, 1000)
-
-    mock_find_last.assert_called()
-
-
-@patch("concurrent.futures.Future.result")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.process_thread_inter_thread_order")
-def test_enforce_inter_thread_order_exception(mock_process_thread, mock_future_result, trace_linker):
-    mock_future_result.side_effect = Exception("Test Exception")
-    kineto_tid_cpu_ops_map = {1: [MagicMock(spec=KinetoOperator)]}
-
-    with pytest.raises(Exception, match="Test Exception"):
-        trace_linker.enforce_inter_thread_order(kineto_tid_cpu_ops_map)
-
-
-def test_extract_pytorch_ops(trace_linker):
-    mock_root_node = MagicMock(spec=PyTorchOperator)
-    mock_child_node = MagicMock(spec=PyTorchOperator)
-
-    mock_root_node.children = [mock_child_node]
-    mock_child_node.children = []
-
-    mock_root_node.id = 1
-    mock_child_node.id = 2
-
-    result = trace_linker.extract_pytorch_ops(mock_root_node)
-    assert len(result) == 2
-    assert result[0].id == 1
-    assert result[1].id == 2
-
-
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.construct_et_plus_data")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.add_thread_and_process_annotations")
-@patch("chakra.src.trace_link.trace_linker.TraceLinker.map_pytorch_to_kineto_ops")
-def test_link_traces(mock_map_ops, mock_add_annotations, mock_construct_et_plus, trace_linker):
-    mock_add_annotations.return_value = ([], [], [])
-    mock_map_ops.return_value = ({}, {}, {}, {}, {})
-    mock_construct_et_plus.return_value = {}
-
-    pytorch_ops = [MagicMock(spec=PyTorchOperator)]
-    kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
-    sorted_kineto_cpu_ops = [MagicMock(spec=KinetoOperator)]
-    sorted_kineto_cpu_op_ts = [100]
-    kineto_correlation_cuda_runtime_map = {1: MagicMock(spec=KinetoOperator)}
-    kineto_rf_id_to_kineto_op_map = {1: MagicMock(spec=KinetoOperator)}
-    kineto_gpu_ops = [MagicMock(spec=KinetoOperator)]
-    kineto_thread_info = {1: (100, 200)}
-    kineto_process_start_time = 50
-    kineto_process_end_time = 300
-
-    trace_linker.link_traces(
-        "pytorch_et_file",
-        pytorch_ops,
-        kineto_cpu_ops,
-        sorted_kineto_cpu_ops,
-        sorted_kineto_cpu_op_ts,
-        kineto_correlation_cuda_runtime_map,
-        kineto_rf_id_to_kineto_op_map,
-        kineto_gpu_ops,
-        kineto_thread_info,
-        kineto_process_start_time,
-        kineto_process_end_time,
-    )
-
-    mock_add_annotations.assert_called_once()
-    mock_map_ops.assert_called_once()
-    mock_construct_et_plus.assert_called_once()


### PR DESCRIPTION
## Summary
- Renamed is_cuda_launch_op to is_kernel_launch_op.
- Added new methods to KinetoOperator: is_cuda_runtime_op, is_cuda_driver_op, and is_ac2g_op.
- Added unit tests for new and existing KinetoOperator methods.
- Updated TraceLinker to use the new is_kernel_launch_op method.
- Refactored code to improve quality and enhance test coverage.

This PR relies on the following PRs. These PRs below should be merged first.
* https://github.com/mlcommons/chakra/pull/122
* https://github.com/mlcommons/chakra/pull/123
* https://github.com/mlcommons/chakra/pull/124
* https://github.com/mlcommons/chakra/pull/125
* https://github.com/mlcommons/chakra/pull/126

## Test Plan
```
$ pip install .                                                              
Processing /Users/theo/chakra-dev
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: protobuf==4.* in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (4.23.4)
Requirement already satisfied: graphviz in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (0.20.1)
Requirement already satisfied: networkx in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (3.2.1)
Requirement already satisfied: pydot in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (2.0.0)
Requirement already satisfied: pyparsing>=3 in /Users/theo/venv/lib/python3.10/site-packages (from pydot->chakra==0.0.4) (3.1.1)
Building wheels for collected packages: chakra
  Building wheel for chakra (pyproject.toml) ... done
  Created wheel for chakra: filename=chakra-0.0.4-py3-none-any.whl size=52840 sha256=31ff1d3c455ef28c7a488e1195075d9db05ae885230ac0903765786da48dabb2
  Stored in directory: /Users/theo/Library/Caches/pip/wheels/1f/cc/a0/f451e6630d3461090be1de9594059abe3c2f5be7ce264deca3
Successfully built chakra
Installing collected packages: chakra
  Attempting uninstall: chakra
    Found existing installation: chakra 0.0.4
    Uninstalling chakra-0.0.4:
      Successfully uninstalled chakra-0.0.4
Successfully installed chakra-0.0.4

$ python3 ci_tools/integration_tests.py --tgz_path tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz --num_ranks 8 --tolerance 0.05 --expected_times_ms 14597 14597 14968 14638 14649 14700 14677 14735
Extracting tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz to tests/data/1.0.2-chakra.0.0.4
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_0.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_0.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_1.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_1.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_2.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_2.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_3.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_3.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_4.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_4.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_5.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_5.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_7.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_7.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json
Running command: chakra_trace_link --pytorch-et-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_6.json --kineto-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_6.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_0.chakra --input_type PyTorch --log_filename /tmp/rank_0.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_1.chakra --input_type PyTorch --log_filename /tmp/rank_1.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_2.chakra --input_type PyTorch --log_filename /tmp/rank_2.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_3.chakra --input_type PyTorch --log_filename /tmp/rank_3.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_4.chakra --input_type PyTorch --log_filename /tmp/rank_4.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_5.chakra --input_type PyTorch --log_filename /tmp/rank_5.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_6.chakra --input_type PyTorch --log_filename /tmp/rank_6.log
Running command: chakra_converter --input_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json --output_filename tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_7.chakra --input_type PyTorch --log_filename /tmp/rank_7.log
Validation successful for /tmp/rank_0.log: 14802300us is within the acceptable range.
Validation successful for /tmp/rank_1.log: 14785782us is within the acceptable range.
Validation successful for /tmp/rank_2.log: 15233261us is within the acceptable range.
Validation successful for /tmp/rank_3.log: 14878058us is within the acceptable range.
Validation successful for /tmp/rank_4.log: 14892945us is within the acceptable range.
Validation successful for /tmp/rank_5.log: 14993779us is within the acceptable range.
Validation successful for /tmp/rank_6.log: 14936348us is within the acceptable range.
Validation successful for /tmp/rank_7.log: 15031147us is within the acceptable range.
```