### PR TITLE
Update PARAM import paths to reflect the latest main branch structure

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         git clone https://github.com/facebookresearch/param.git
         cd param/et_replay
-        git checkout 884a1f0154a16e2c170e456f8027f2646c9108ae
-        sed -i '/param_bench/d' pyproject.toml
+        git checkout 7b19f586dd8b267333114992833a0d7e0d601630
         pip install .
 
     - name: Test chakra_trace_link Without Arguments

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         git clone https://github.com/facebookresearch/param.git
         cd param/et_replay
-        git checkout 884a1f0154a16e2c170e456f8027f2646c9108ae
-        sed -i '/param_bench/d' pyproject.toml
+        git checkout 7b19f586dd8b267333114992833a0d7e0d601630
         pip install .
 
     - name: Install Dependencies

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -31,7 +31,7 @@ Installing PARAM is necessary for Chakra to function properly as it imports esse
 ```bash
 $ git clone git@github.com:facebookresearch/param.git
 $ cd param/et_replay
-$ git checkout ea12ab702712e9986db85cd5773eb5902f28af2a
+$ git checkout 7b19f586dd8b267333114992833a0d7e0d601630
 $ pip install .
 ```
 

--- a/src/trace_link/chakra_device_trace_loader.py
+++ b/src/trace_link/chakra_device_trace_loader.py
@@ -3,7 +3,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Tuple
 
-from et_replay.lib.utils import read_dictionary_from_json_file
+from et_replay.utils import read_dictionary_from_json_file
 
 from .kineto_operator import KinetoOperator
 

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -2,8 +2,8 @@ import logging
 import sys
 from typing import List
 
-from et_replay.lib.execution_trace import Node as PyTorchOperator
-from et_replay.lib.utils import load_execution_trace_file
+from et_replay.execution_trace import Node as PyTorchOperator
+from et_replay.utils import load_execution_trace_file
 
 # Increase the recursion limit for deep Chakra host execution traces.
 sys.setrecursionlimit(10**6)

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from et_replay.lib.execution_trace import Node as PyTorchOperator
+from et_replay.execution_trace import Node as PyTorchOperator
 
 
 class KinetoOperator:

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -5,11 +5,11 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Optional, Tuple
 
-from et_replay.lib.execution_trace import (
+from et_replay.execution_trace import (
     EXECUTION_TRACE_PROCESS_ANNOTATION,
     EXECUTION_TRACE_THREAD_ANNOTATION,
 )
-from et_replay.lib.execution_trace import Node as PyTorchOperator
+from et_replay.execution_trace import Node as PyTorchOperator
 
 from .chakra_device_trace_loader import ChakraDeviceTraceLoader
 from .chakra_host_trace_loader import ChakraHostTraceLoader

--- a/tests/trace_link/test_chakra_host_trace_loader.py
+++ b/tests/trace_link/test_chakra_host_trace_loader.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from chakra.src.trace_link.chakra_host_trace_loader import ChakraHostTraceLoader
-from et_replay.lib.execution_trace import Node as PyTorchOperator
+from et_replay.execution_trace import Node as PyTorchOperator
 
 
 @pytest.fixture

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -4,11 +4,11 @@ import pytest
 from chakra.src.trace_link.kineto_operator import KinetoOperator
 from chakra.src.trace_link.trace_linker import TraceLinker
 from chakra.src.trace_link.unique_id_assigner import UniqueIdAssigner
-from et_replay.lib.execution_trace import (
+from et_replay.execution_trace import (
     EXECUTION_TRACE_PROCESS_ANNOTATION,
     EXECUTION_TRACE_THREAD_ANNOTATION,
 )
-from et_replay.lib.execution_trace import Node as PyTorchOperator
+from et_replay.execution_trace import Node as PyTorchOperator
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Update PARAM import paths to reflect the latest main branch structure

## Test Plan
```
$ pip install . 
Processing /Users/theo/chakra-dev
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: protobuf==4.* in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (4.23.4)
Requirement already satisfied: graphviz in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (0.20.1)
Requirement already satisfied: networkx in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (3.2.1)
Requirement already satisfied: pydot in /Users/theo/venv/lib/python3.10/site-packages (from chakra==0.0.4) (2.0.0)
Requirement already satisfied: pyparsing>=3 in /Users/theo/venv/lib/python3.10/site-packages (from pydot->chakra==0.0.4) (3.1.1)
Building wheels for collected packages: chakra
  Building wheel for chakra (pyproject.toml) ... done
  Created wheel for chakra: filename=chakra-0.0.4-py3-none-any.whl size=55395 sha256=9c832b33d7faa7a022a89daf26d29f148533a7dfce69bf559680c10cded74ab3
  Stored in directory: /Users/theo/Library/Caches/pip/wheels/1f/cc/a0/f451e6630d3461090be1de9594059abe3c2f5be7ce264deca3
Successfully built chakra
Installing collected packages: chakra
  Attempting uninstall: chakra
    Found existing installation: chakra 0.0.4
    Uninstalling chakra-0.0.4:
      Successfully uninstalled chakra-0.0.4
Successfully installed chakra-0.0.4

$ python3 ci_tools/integration_tests.py --tgz_path tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz --num_ranks 8 --tolerance 0.05 --expected_times_ms 14597 14597 14968 14638 14649 14700 14677 14735
Extracting tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05.tgz to tests/data/1.0.2-chakra.0.0.4
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_0.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_0.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_1.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_1.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_2.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_2.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_3.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_3.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_4.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_4.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_6.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_6.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_7.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_7.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json
Running command: chakra_trace_link --chakra-host-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_host_et_5.json --chakra-device-trace tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/kineto_5.json --output-file tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json
Running command: chakra_converter --log-filename /tmp/rank_0.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_0.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_0.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_1.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_1.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_1.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_3.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_3.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_3.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_2.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_2.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_2.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_4.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_4.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_4.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_7.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_7.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_7.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_6.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_6.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_6.chakra --simulate
Running command: chakra_converter --log-filename /tmp/rank_5.log PyTorch --input tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_et_plus_5.json --output tests/data/1.0.2-chakra.0.0.4/llama_pytorch24.05/chakra_final_5.chakra --simulate

$ tail -n 2 *.log 
==> rank_0.log <==
DEBUG [07/24/2024 07:08:41 AM] GPU Node ID 301192 on stream 7 completed at 14488271us, tid: stream 7
DEBUG [07/24/2024 07:08:41 AM] Simulation of Chakra node execution completed.

==> rank_1.log <==
DEBUG [07/24/2024 07:10:21 AM] GPU Node ID 301192 on stream 7 completed at 14489195us, tid: stream 7
DEBUG [07/24/2024 07:10:21 AM] Simulation of Chakra node execution completed.

==> rank_2.log <==
DEBUG [07/24/2024 07:00:36 AM] GPU Node ID 301192 on stream 7 completed at 14550790us, tid: stream 7
DEBUG [07/24/2024 07:00:36 AM] Simulation of Chakra node execution completed.

==> rank_3.log <==
DEBUG [07/24/2024 07:07:29 AM] GPU Node ID 301192 on stream 7 completed at 14418327us, tid: stream 7
DEBUG [07/24/2024 07:07:29 AM] Simulation of Chakra node execution completed.

==> rank_4.log <==
DEBUG [07/24/2024 07:07:26 AM] GPU Node ID 301192 on stream 7 completed at 14500584us, tid: stream 7
DEBUG [07/24/2024 07:07:26 AM] Simulation of Chakra node execution completed.

==> rank_5.log <==
DEBUG [07/24/2024 07:04:33 AM] GPU Node ID 301192 on stream 7 completed at 14308678us, tid: stream 7
DEBUG [07/24/2024 07:04:33 AM] Simulation of Chakra node execution completed.

==> rank_6.log <==
DEBUG [07/24/2024 07:07:00 AM] GPU Node ID 301192 on stream 7 completed at 14385408us, tid: stream 7
DEBUG [07/24/2024 07:07:00 AM] Simulation of Chakra node execution completed.

==> rank_7.log <==
DEBUG [07/24/2024 07:02:29 AM] GPU Node ID 301192 on stream 7 completed at 14398107us, tid: stream 7
DEBUG [07/24/2024 07:02:29 AM] Simulation of Chakra node execution completed.
```