### PR TITLE
Encode communicator groups in Chakra traces 

### DIFF
--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -225,8 +225,10 @@ class PyTorchConverter:
             protobuf_node_map (Dict[int, ChakraNode]): Dictionary where the converted Protobuf nodes will be stored.
         """
         for _, json_node in json_node_map.items():
-            if (json_node.get_op_type() == PyTorchNodeType.CPU_OP) or (
-                json_node.get_op_type() == PyTorchNodeType.LABEL
+            if (
+                (json_node.get_op_type() == PyTorchNodeType.CPU_OP)
+                or (json_node.get_op_type() == PyTorchNodeType.LABEL)
+                or (json_node.get_op_type() == PyTorchNodeType.METADATA)
             ):
                 chakra_node = self.convert_json_to_protobuf_node(json_node_map, protobuf_node_map, json_node)
                 protobuf_node_map[chakra_node.id] = chakra_node

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -244,6 +244,7 @@ class PyTorchConverter:
                             [
                                 ChakraAttr(name="comm_type", int64_val=collective_comm_type),
                                 ChakraAttr(name="comm_size", int64_val=pytorch_gpu_node.comm_size),
+                                *( [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)] if pytorch_gpu_node.pg_name != "" else [] ),
                             ]
                         )
 
@@ -251,6 +252,7 @@ class PyTorchConverter:
                         chakra_gpu_node.attr.extend(
                             [
                                 ChakraAttr(name="comm_size", int64_val=pytorch_gpu_node.comm_size),
+                                *( [ChakraAttr(name="pg_name", string_val=pytorch_gpu_node.pg_name)] if pytorch_gpu_node.pg_name != "" else [] ),
                             ]
                         )
 

--- a/src/converter/pytorch_node.py
+++ b/src/converter/pytorch_node.py
@@ -13,11 +13,13 @@ class PyTorchNodeType(Enum):
         CPU_OP (int): Represents a CPU operation.
         GPU_OP (int): Represents a GPU operation.
         LABEL (int): Represents a non-operator node (e.g., labels).
+        METADATA (int): Represents a metadata node (e.g., process group initialization).
     """
 
     CPU_OP = 1
     GPU_OP = 2
     LABEL = 3  # Non-operator nodes
+    METADATA = 4 # Metadata nodes
 
 
 class PyTorchNode:
@@ -120,7 +122,9 @@ class PyTorchNode:
         Returns
             PyTorchNodeType: The type of the PyTorch operation.
         """
-        if self.is_gpu_op():
+        if "process_group:init" in self.name:
+            return PyTorchNodeType.METADATA
+        elif self.is_gpu_op():
             return PyTorchNodeType.GPU_OP
         elif hasattr(self, "op_schema") or hasattr(self, "outputs"):
             return PyTorchNodeType.CPU_OP

--- a/src/converter/pytorch_node.py
+++ b/src/converter/pytorch_node.py
@@ -44,6 +44,7 @@ class PyTorchNode:
         inter_thread_dep (Any): Inter-thread dependency of the node.
         cat (Any): Category of the node.
         stream (int): Stream associated with the node.
+        pg_name (str): Process Group name for the inter-GPU communication.
     """
 
     SUPPORTED_VERSIONS = ["1.0.2-chakra.0.0.4", "1.0.3-chakra.0.0.4", "1.1.0-chakra.0.0.4"]
@@ -111,6 +112,10 @@ class PyTorchNode:
         self.inter_thread_dep = node_data.get("inter_thread_dep")
         self.cat = node_data.get("cat")
         self.stream = node_data.get("stream", 0)
+        # In Colletive comms nodes, pg_name is in node_data if exists.
+        # In SendRecv nodes, pg_name is in the attrs if exists.
+        # Otherwise, pg_name is not present.
+        self.pg_name = node_data.get("pg_name", "")
 
         for attr in node_data.get("attrs", []):
             setattr(self, attr["name"], attr["value"])

--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -32,6 +32,8 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
       this->comm_dst_ = static_cast<uint32_t>(attr.int32_val());
     } else if (attr_name == "comm_tag") {
       this->comm_tag_ = static_cast<uint32_t>(attr.int32_val());
+    } else if (attr_name == "pg_name") {
+      this->pg_name_ = static_cast<string>(attr.string_val());
     } else {
       this->other_attrs_.emplace(attr_name, attr);
     }
@@ -137,4 +139,8 @@ uint32_t ETFeederNode::comm_dst() {
 
 uint32_t ETFeederNode::comm_tag() {
   return comm_tag_;
+}
+
+string ETFeederNode::pg_name() {
+  return pg_name_;
 }

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -37,6 +37,7 @@ class ETFeederNode {
   uint32_t comm_src();
   uint32_t comm_dst();
   uint32_t comm_tag();
+  std::string pg_name();
 
  private:
   void assign_attr_val(
@@ -64,6 +65,7 @@ class ETFeederNode {
   uint32_t comm_src_;
   uint32_t comm_dst_;
   uint32_t comm_tag_;
+  std::string pg_name_;
 };
 
 } // namespace Chakra

--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -25,6 +25,7 @@ class KinetoOperator:
         stream (Optional[int]): CUDA stream identifier associated with the operator.
         rf_id (Optional[int]): Record function identifier.
         correlation (int): Identifier used to correlate CUDA runtime and GPU operations.
+        pg_name (Optional[str]): Process Group name for the collective communication.
     """
 
     def __init__(self, kineto_op: Dict[str, Any]) -> None:
@@ -51,6 +52,7 @@ class KinetoOperator:
         self.stream: Optional[int] = kineto_op.get("args", {}).get("stream", None)
         self.rf_id: Optional[int] = kineto_op.get("args", {}).get("Record function id", None)
         self.correlation: int = kineto_op.get("args", {}).get("correlation", -1)
+        self.pg_name: Optional[str] = kineto_op.get("args", {}).get("Process Group Name", None)
 
     def __repr__(self) -> str:
         """
@@ -153,3 +155,14 @@ class KinetoOperator:
         """
         gpu_categories = {"kernel", "gpu_memcpy"}
         return self.category in gpu_categories
+
+    def is_inter_gpu_comms_op(self) -> bool:
+        """
+        Check if the operator is a inter-GPU communication operator based on its name.
+
+        Both point-to-point send/receive primitives and collective communication primitives are considered.
+
+        Returns
+            bool: True if it's a inter-GPU communication, otherwise False.
+        """
+        return "ncclDevKernel" in self.name

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -755,8 +755,14 @@ class TraceLinker:
                     "exclusive_dur": gpu_op.exclusive_dur,
                     "ts": gpu_op.timestamp,
                     "stream": gpu_op.stream,
+                    **(
+                        {"pg_name": gpu_op.pg_name}
+                        if gpu_op.is_inter_gpu_comms_op() and gpu_op.pg_name is not None
+                        else {}
+                    ),
                 }
             )
+
             updated_gpu_ops.append(new_gpu_op)
 
         return updated_gpu_ops

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -469,6 +469,7 @@ def test_process_dependent_gpu_ops(trace_linker, orig_op_id, cpu_op, kineto_gpu_
         gpu_op.inclusive_dur = gpu_op_data["inclusive_dur"]
         gpu_op.exclusive_dur = gpu_op_data["exclusive_dur"]
         gpu_op.stream = gpu_op_data["stream"]
+        gpu_op.pg_name = gpu_op_data.get("pg_name", None)
         kineto_gpu_op_objects.append(gpu_op)
 
     host_op_id_to_kineto_ops_map = {orig_op_id: kineto_gpu_op_objects}
@@ -497,6 +498,8 @@ def test_process_dependent_gpu_ops(trace_linker, orig_op_id, cpu_op, kineto_gpu_
         assert updated_gpu_op["exclusive_dur"] == kineto_gpu_op_objects[i].exclusive_dur
         assert updated_gpu_op["ts"] == kineto_gpu_op_objects[i].timestamp
         assert updated_gpu_op["stream"] == kineto_gpu_op_objects[i].stream
+        if kineto_gpu_op_objects[i].is_inter_gpu_comms_op() and kineto_gpu_op_objects[i].pg_name is not None:
+            assert updated_gpu_op["pg_name"] == kineto_gpu_op_objects[i].pg_name
 
 
 @patch("builtins.open", new_callable=MagicMock)


### PR DESCRIPTION
## Summary
Encoding communicator groups in Chakra traces is essential for accurately simulating collective communication when multiple communicator groups are present. With the latest PyTorch version, you can collect communicator groups in Chakra host traces (PyTorch execution traces) and Chakra device traces (Kineto traces). In Chakra host traces, you will find a process_group:init operator that presents the available communicator groups in the run. Moreover, whenever there is a collective communication operator, you can find essential fields in its attributes to correlate the collective operator with a communicator group. You can use the pg_name field for correlation. Additionally, Chakra device traces now include communicator group information in ncclDevKernel_* operators.

Below is an example with AllReduce.
```
{
  "ph": "X",
  "cat": "kernel",
  "name": "ncclDevKernel_AllReduce_Sum_bf16_RING_LL(ncclDevKernelArgsStorage<4096ul>)",
  "pid": 0,
  "tid": 60,
  "args": {
    "External id": 14728,
    "queued": 0,
    "device": 0,
    "context": 1,
    "stream": 60,
    "correlation": 136816,
    "registers per thread": 96,
    "shared memory": 89296,
    "blocks per SM": 0.222222,
    "warps per SM": 3.777778,
    "grid": [24, 1, 1],
    "block": [544, 1, 1],
    "est. achieved occupancy %": 0,
    "Collective name": "allreduce",
    "In msg nelems": 6291456,
    "Out msg nelems": 6291456,
    "Group size": 2,
    "dtype": "BFloat16",
    "In split size": "[]",
    "Out split size": "[]",
    "Process Group Name": "27",
    "Process Group Description": "undefined",
    "Process Group Ranks": "[0, 1]"
  }
}
```

It includes "Group size," "Process Group Name," "Process Group Description," and "Process Group Ranks."

Most of the information, except for Process Group Name, is redundant since it is already defined in the metadata, as shown in the example below.

```
"distributedInfo": {
  "backend": "nccl",
  "rank": 0,
  "world_size": 8,
  "pg_count": 67,
  "pg_config": [
    {"pg_name": "0", "pg_desc": "default_pg", "backend_config": "cuda:nccl", "pg_size": 8, "ranks": [0, 1, 2, 3, 4, 5, 6, 7]},
    {"pg_name": "1", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 2]},
    {"pg_name": "2", "pg_desc": "undefined", "backend_config": "cpu:gloo,cuda:gloo", "pg_size": 2, "ranks": [0, 2]},
    {"pg_name": "9", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 2]},
    {"pg_name": "10", "pg_desc": "undefined", "backend_config": "cpu:gloo,cuda:gloo", "pg_size": 2, "ranks": [0, 2]},
    {"pg_name": "17", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 1, "ranks": [0]},
    {"pg_name": "25", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 4, "ranks": [0, 1, 4, 5]},
    {"pg_name": "27", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 1]},
    {"pg_name": "31", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 4]},
    {"pg_name": "32", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 4]},
    {"pg_name": "33", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 1, "ranks": [0]},
    {"pg_name": "43", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 4, "ranks": [0, 1, 2, 3]},
    {"pg_name": "45", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 4, "ranks": [0, 1, 2, 3]},
    {"pg_name": "47", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 1]},
    {"pg_name": "51", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 1, "ranks": [0]},
    {"pg_name": "59", "pg_desc": "undefined", "backend_config": "cuda:nccl", "pg_size": 2, "ranks": [0, 2]},
    {"pg_name": "60", "pg_desc": "undefined", "backend_config": "cpu:gloo,cuda:gloo", "pg_size": 2, "ranks": [0, 2]}
  ],
  "nccl_version": "2.22.3"
}
```

This PR allows users to identify the pg_init operator by classifying the node explicitly as a metadata node. Moreover, this PR explicitly encodes pg_name as an attribute of collective communication operators. Finally, this PR updates the feeder so that simulators can parse and access the pg_name field easily.

## Test Plan

Generate Chakra HDT traces.
```
for rank in 0 1 2 3 4 5 6 7; do
    chakra_trace_link --chakra-host-trace gpt3_126m_1.1.0-chakra.0.0.4/et_${rank}.json --chakra-device-trace gpt3_126m_1.1.0-chakra.0.0.4/kineto_${rank}.json --output-file gpt3_126m_1.1.0-chakra.0.0.4/rank_${rank}.json   
    chakra_converter PyTorch --input gpt3_126m_1.1.0-chakra.0.0.4/rank_${rank}.json --output gpt3_126m_1.1.0-chakra.0.0.4/rank.${rank}.et
done
```

Check through Jsonizer
```
for rank in 0 1 2 3 4 5 6 7; do
    chakra_jsonizer --input_filename gpt3_126m_1.1.0-chakra.0.0.4/rank_${rank}.json --output_filename gpt3_126m_1.1.0-chakra.0.0.4/rank.${rank}.json
done
```

Test ETFeeder with ASTRA-Sim
```
mv ../gpt3_126m_1.1.0-chakra.0.0.4/ ./gpt3 
./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware --workload-configuration=/home/un-gpu/Project/jpark/astra-sim/gpt3/rank --system-configuration=./inputs/system/Ring.json --network-configuratio
n=./inputs/network/analytical/Ring.yml --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
```
Code in the ASTRA-Sim using ETFeeder
```
  if (!node->is_cpu_op() && (node->type() == ChakraNodeType::COMM_COLL_NODE)) {
    if(node->pg_name().empty() == false){
      cout << "Node Name: " << node->name() << endl;
      cout << "Process Group Name" << node->pg_name() << endl;
    }
  }
```

## Trace
The traces are collected From PyTorch Schema 1.1.0.chakra-0.0.4
[gpt3_126m_1.1.0-chakra.0.0.4.zip](https://github.com/user-attachments/files/16365955/gpt3_126m_1.1.0-chakra.0.0.4.zip)
