### PR TITLE
keep original data_deps while resolving graph

### DIFF
--- a/src/feeder/et_feeder.cpp
+++ b/src/feeder/et_feeder.cpp
@@ -68,17 +68,10 @@ shared_ptr<ETFeederNode> ETFeeder::lookupNode(uint64_t node_id) {
 void ETFeeder::freeChildrenNodes(uint64_t node_id) {
   shared_ptr<ETFeederNode> node = dep_graph_[node_id];
   for (auto child : node->getChildren()) {
-    auto child_chakra = child->getChakraNode();
-    for (auto it = child_chakra->mutable_data_deps()->begin();
-         it != child_chakra->mutable_data_deps()->end();
-         ++it) {
-      if (*it == node_id) {
-        child_chakra->mutable_data_deps()->erase(it);
-        break;
-      }
-    }
-    if (child_chakra->data_deps().size() == 0) {
-      dep_free_node_id_set_.emplace(child_chakra->id());
+    auto& unresolved_data_deps = child->mutable_unresolved_data_deps();
+    unresolved_data_deps.erase(node_id);
+    if (unresolved_data_deps.size() == 0) {
+      dep_free_node_id_set_.emplace(child->id());
       dep_free_node_queue_.emplace(child);
     }
   }

--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -83,58 +83,58 @@ bool ETFeederNode::has_other_attr(const string& attr_name) const {
   return item != this->other_attrs_.end();
 }
 
-uint64_t ETFeederNode::id() {
+uint64_t ETFeederNode::id() const {
   return id_;
 }
 
-string ETFeederNode::name() {
+string ETFeederNode::name() const {
   return name_;
 }
 
-bool ETFeederNode::is_cpu_op() {
+bool ETFeederNode::is_cpu_op() const {
   return is_cpu_op_;
 }
 
-ChakraProtoMsg::NodeType ETFeederNode::type() {
+ChakraProtoMsg::NodeType ETFeederNode::type() const {
   return node_->type();
 }
 
-uint64_t ETFeederNode::runtime() {
+uint64_t ETFeederNode::runtime() const {
   return runtime_;
 }
 
-uint64_t ETFeederNode::num_ops() {
+uint64_t ETFeederNode::num_ops() const {
   return num_ops_;
 }
 
-uint32_t ETFeederNode::tensor_loc() {
+uint32_t ETFeederNode::tensor_loc() const {
   return tensor_loc_;
 }
 
-uint64_t ETFeederNode::tensor_size() {
+uint64_t ETFeederNode::tensor_size() const {
   return tensor_size_;
 }
 
-ChakraProtoMsg::CollectiveCommType ETFeederNode::comm_type() {
+ChakraProtoMsg::CollectiveCommType ETFeederNode::comm_type() const {
   return comm_type_;
 }
 
-uint32_t ETFeederNode::comm_priority() {
+uint32_t ETFeederNode::comm_priority() const {
   return comm_priority_;
 }
 
-uint64_t ETFeederNode::comm_size() {
+uint64_t ETFeederNode::comm_size() const {
   return comm_size_;
 }
 
-uint32_t ETFeederNode::comm_src() {
+uint32_t ETFeederNode::comm_src() const {
   return comm_src_;
 }
 
-uint32_t ETFeederNode::comm_dst() {
+uint32_t ETFeederNode::comm_dst() const {
   return comm_dst_;
 }
 
-uint32_t ETFeederNode::comm_tag() {
+uint32_t ETFeederNode::comm_tag() const {
   return comm_tag_;
 }

--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -152,6 +152,6 @@ uint32_t ETFeederNode::comm_tag() const {
   return comm_tag_;
 }
 
-string ETFeederNode::pg_name() {
+string ETFeederNode::pg_name() const {
   return pg_name_;
 }

--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -10,6 +10,9 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
   this->runtime_ = node->duration_micros();
   this->is_cpu_op_ = 1;
 
+  for (uint64_t unresolved_data_dep : node->data_deps())
+    this->unresolved_data_deps.insert(unresolved_data_dep);
+
   for (const auto& attr : node->attr()) {
     const string& attr_name = attr.name();
 
@@ -81,6 +84,14 @@ const ChakraProtoMsg::AttributeProto& ETFeederNode::get_other_attr(
 bool ETFeederNode::has_other_attr(const string& attr_name) const {
   const auto& item = this->other_attrs_.find(attr_name);
   return item != this->other_attrs_.end();
+}
+
+const std::unordered_set<uint64_t>& ETFeederNode::unresolved_data_deps() const {
+  return this->unresolved_data_deps_;
+}
+
+std::unordered_set<uint64_t>& ETFeederNode::mutable_unresolved_data_deps() {
+  return this->unresolved_data_deps_;
 }
 
 uint64_t ETFeederNode::id() const {

--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -11,7 +11,7 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
   this->is_cpu_op_ = 1;
 
   for (uint64_t unresolved_data_dep : node->data_deps())
-    this->unresolved_data_deps.insert(unresolved_data_dep);
+    this->unresolved_data_deps_.insert(unresolved_data_dep);
 
   for (const auto& attr : node->attr()) {
     const string& attr_name = attr.name();

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -38,6 +38,7 @@ class ETFeederNode {
   uint32_t comm_src() const;
   uint32_t comm_dst() const;
   uint32_t comm_tag() const;
+  std::string pg_name() const;
   const std::unordered_set<uint64_t>& unresolved_data_deps() const;
   std::unordered_set<uint64_t>& mutable_unresolved_data_deps();
 

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -24,20 +24,20 @@ class ETFeederNode {
       const std::string& attr_name) const;
   bool has_other_attr(const std::string& attr_name) const;
 
-  uint64_t id();
-  std::string name();
-  bool is_cpu_op();
-  ChakraProtoMsg::NodeType type();
-  uint64_t runtime();
-  uint64_t num_ops();
-  uint32_t tensor_loc();
-  uint64_t tensor_size();
-  ChakraProtoMsg::CollectiveCommType comm_type();
-  uint32_t comm_priority();
-  uint64_t comm_size();
-  uint32_t comm_src();
-  uint32_t comm_dst();
-  uint32_t comm_tag();
+  uint64_t id() const;
+  std::string name() const;
+  bool is_cpu_op() const;
+  ChakraProtoMsg::NodeType type() const;
+  uint64_t runtime() const;
+  uint64_t num_ops() const;
+  uint32_t tensor_loc() const;
+  uint64_t tensor_size() const;
+  ChakraProtoMsg::CollectiveCommType comm_type() const;
+  uint32_t comm_priority() const;
+  uint64_t comm_size() const;
+  uint32_t comm_src() const;
+  uint32_t comm_dst() const;
+  uint32_t comm_tag() const;
 
  private:
   void assign_attr_val(

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -40,11 +40,6 @@ class ETFeederNode {
   uint32_t comm_tag() const;
 
  private:
-  void assign_attr_val(
-      std::shared_ptr<ChakraProtoMsg::Node> node,
-      int i,
-      void* member);
-
   std::shared_ptr<ChakraProtoMsg::Node> node_{nullptr};
   std::unordered_set<std::shared_ptr<ETFeederNode>> children_set_{};
   std::vector<std::shared_ptr<ETFeederNode>> children_vec_{};

--- a/src/feeder/et_feeder_node.h
+++ b/src/feeder/et_feeder_node.h
@@ -38,6 +38,8 @@ class ETFeederNode {
   uint32_t comm_src() const;
   uint32_t comm_dst() const;
   uint32_t comm_tag() const;
+  const std::unordered_set<uint64_t>& unresolved_data_deps() const;
+  std::unordered_set<uint64_t>& mutable_unresolved_data_deps();
 
  private:
   std::shared_ptr<ChakraProtoMsg::Node> node_{nullptr};
@@ -46,6 +48,7 @@ class ETFeederNode {
   std::vector<uint64_t> dep_unresolved_parent_ids_{};
   std::unordered_map<std::string, const ChakraProtoMsg::AttributeProto&>
       other_attrs_{};
+  std::unordered_set<uint64_t> unresolved_data_deps_{};
 
   uint64_t id_;
   std::string name_;


### PR DESCRIPTION
Target Issue #148 
## Summary
One of the future works on astrasim about memory requires getting the original data dependency from the workload. However, in the current implementation of ETFeeder the original data_deps will be mutated for recording dependency resolving. Here we introduce a duplication of data_deps called `unresolved_data_deps` which is specifically used for dependency resolving. This way we can keep original data_deps during resolving for purples of memory analysis.

## Test Plan
Test it with AstraSIM `run/example`

