### PR TITLE
Dumping collective metadata to csv for each rank

### DIFF
--- a/src/converter/converter.py
+++ b/src/converter/converter.py
@@ -33,7 +33,7 @@ def convert_text(args: argparse.Namespace) -> None:
 def convert_pytorch(args: argparse.Namespace) -> None:
     """Convert PyTorch input trace to Chakra execution trace."""
     converter = PyTorchConverter()
-    converter.convert(args.input, args.output, args.simulate)
+    converter.convert(args.input, args.output, args.simulate, args.dump_collective_nodes)
 
 
 def main() -> None:
@@ -70,6 +70,13 @@ def main() -> None:
             "or simulator against actual measured values using tools like chrome://tracing or https://perfetto.dev/. "
             "Read the duration of the timeline and compare the total execution time against the final simulation time "
             "of a trace. Disabled by default because it takes a long time."
+        ),
+    )
+    pytorch_parser.add_argument(
+        "--dump_collective_nodes",
+        action="store_true",
+        help=(
+            "Dumping all collective operations in the trace to csv, to further processing them."
         ),
     )
     pytorch_parser.set_defaults(func=convert_pytorch)

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -40,7 +40,10 @@ class PyTorchConverter:
             output_filename (str): Output Chakra host + device execution trace in the protobuf format.
             simulate (bool): Flag to indicate whether to simulate the execution of the converted trace. If True,
                 the method will simulate the execution after writing the protobuf trace to the output file.
-                :param dump_collective_nodes:
+            dump_collective_nodes (bool): Flag to indicate whether to dump all collective opreations basic
+                metadata to a csv file. If True, the method will dump the information after writing the protobuf 
+                trace to the output file. The flag assumes the filename is {some-string}_{rank}.{some-string}
+                because the dump file uses the rank to create unique file for each rank.
         """
         json_trace = self.load_json_execution_traces(input_filename)
         json_metadata, json_node_map = self.parse_json_trace(json_trace)


### PR DESCRIPTION
## Summary
Adding a function that loops for the nodes and for each collective node dump basic data into csv file (data like the node id, the node name that includes the collective name, the collective msg size, the pg_name, root rank if needed, etc.

the dump allows to further processing the trace for example if we want to create collective implementation of those high-level collective commands.

## Test Plan
Running it on several et_{rank}.json files, and see the dump created.

## Additional Notes
if, for each collective node, one of the following attributes is missing: pg_name, coll_size, root_rank, the dump will indicate that in separate field so it will not fail on that. The user will need to check of it's OK. for example, not every node needs root_rank, so it's OK if it's missing for AllReduce for example, but not for Broadcase.
