### PR TITLE
fix is_cpu_op bug

### DIFF
--- a/src/converter/text_converter.py
+++ b/src/converter/text_converter.py
@@ -103,6 +103,7 @@ class TextConverter:
 
     def get_comm_coll_node(self, layer_name: str, comm_type: str, comm_size: int) -> Any:
         node = self.get_node(f"COMM_COLL_NODE_{layer_name}_{comm_type}", COMM_COLL_NODE)
+        node.attr.append(ChakraAttr(name="is_cpu_op", bool_val=False))
         node.attr.append(ChakraAttr(name="comm_type", int64_val=self.get_comm_type(comm_type)))
         node.attr.append(ChakraAttr(name="comm_size", uint64_val=comm_size))
         return node


### PR DESCRIPTION
## Summary
Converting ASTRA-sim 1.0 text input files does not add `is_cpu_op` field. As a result, the COMM nodes are always skipped by the workload layer of astra-sim, as reported in https://github.com/mlcommons/chakra/issues/144 and https://github.com/astra-sim/astra-sim/issues/224. 
Simply adding the attribute might fix the bug.
