### PR TITLE
Specify the kineto filepath explicitly when running HTA analysis

### DIFF
--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -117,7 +117,7 @@ class TraceLinker:
         sync_dependencies = {}
         absolute_kineto_file = os.path.abspath(kineto_file)
         trace_dir = os.path.dirname(absolute_kineto_file)
-        trace_analysis = TraceAnalysis(trace_dir=trace_dir)
+        trace_analysis = TraceAnalysis(trace_dir=trace_dir, trace_files={rank: kineto_file})
         cp_graph, success = trace_analysis.critical_path_analysis(
             rank=rank, annotation=annotation, instance_id=instance_id
         )


### PR DESCRIPTION
## Summary

Without specifying the kineto filepath explicitly, HTA may pick arbitrary files from the `trace_dir` and either provide incorrect analysis results, or fail in some weird ways.

## Test Plan

I tested it locally within my setup, and also run the existing test suite, but I guess this is not enough to move forward.
What would be the best way to add a test case capturing such a behavior? Shall I add some more test data?
Would appreciate any suggestions on how to make this PR better 🙌

## Additional Notes


As a concrete example, I have the following files in one folder:

```
trace_linked.0.json
trace_kineto.0.json
trace_pytorch.0.json
```

When I run the linker as follows:

```bash
chakra_trace_link --rank 0 \
  --chakra-host-trace trace_pytorch.0.json \
  --chakra-device-trace trace_kineto.0.json \
  --output-file trace_linked.0.json
```

then the underlying HTA analysis will pick all the files in the `trace_dir`, despite the fact that I explicitly specified which files to link.

This is one of the errors I hit within my setup:

<details>
  <summary>Failure</summary>

```
> chakra_trace_link --rank 0 --chakra-host-trace trace_pytorch.0.json --chakra-device-trace trace_kineto.0.json --output-file trace_linked.0.json
[2024-11-11 12:20:19,449] trace.py:328 [INFO]: ~/traces
[2024-11-11 12:20:19,514] trace_file.py:61 [ERROR]: If the trace file does not have the rank specified in it, then add the following snippet key to the json files to use HTA; "distributedInfo": {"rank": 0}. If there are multiple traces files, then each file should have a unique rank value.
[2024-11-11 12:20:19,521] trace_file.py:61 [ERROR]: If the trace file does not have the rank specified in it, then add the following snippet key to the json files to use HTA; "distributedInfo": {"rank": 0}. If there are multiple traces files, then each file should have a unique rank value.
[2024-11-11 12:20:19,529] trace_file.py:61 [ERROR]: If the trace file does not have the rank specified in it, then add the following snippet key to the json files to use HTA; "distributedInfo": {"rank": 0}. If there are multiple traces files, then each file should have a unique rank value.
[2024-11-11 12:20:19,529] trace_file.py:92 [WARNING]: There is no item in the rank to trace file map.
[2024-11-11 12:20:19,529] trace.py:474 [INFO]: ranks=[]
[2024-11-11 12:20:19,529] trace.py:480 [ERROR]: The list of ranks to be parsed is empty.
[2024-11-11 12:20:19,529] trace.py:483 [WARNING]: leaving parse_traces duration=0.00 seconds

Traceback (most recent call last):
  File "~/chakra/.venv/bin/chakra_trace_link", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "~/chakra/.venv/lib/python3.11/site-packages/chakra/src/trace_link/trace_link.py", line 47, in main
    linker.link(args.rank, args.chakra_host_trace, args.chakra_device_trace, args.output_file)
  File "~/chakra/.venv/lib/python3.11/site-packages/chakra/src/trace_link/trace_linker.py", line 70, in link
    sync_deps = self.load_sync_dependencies(rank, chakra_device_trace)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/chakra/.venv/lib/python3.11/site-packages/chakra/src/trace_link/trace_linker.py", line 120, in load_sync_dependencies
    trace_analysis = TraceAnalysis(trace_dir=trace_dir)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/chakra/.venv/lib/python3.11/site-packages/hta/trace_analysis.py", line 37, in __init__
    self.t.load_traces(include_last_profiler_step)
  File "~/chakra/.venv/lib/python3.11/site-packages/hta/common/trace.py", line 353, in load_traces
    self.align_and_filter_trace(include_last_profiler_step)
  File "~/chakra/.venv/lib/python3.11/site-packages/hta/common/trace.py", line 493, in align_and_filter_trace
    self._align_all_ranks()
  File "~/chakra/.venv/lib/python3.11/site-packages/hta/common/trace.py", line 615, in _align_all_ranks
    self.min_ts = min(trace_df["ts"].min() for trace_df in self.traces.values())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() arg is an empty sequence
```

</details>

And here is the output with the patched version:

<details>
  <summary>Success</summary>

```
> chakra_trace_link --rank 0 --chakra-host-trace trace_pytorch.0.json --chakra-device-trace trace_kineto.0.json --output-file trace_linked.0.json
[2024-11-11 12:24:35,997] trace.py:328 [INFO]: ~/traces
[2024-11-11 12:24:35,997] trace.py:474 [INFO]: ranks=[0]
[2024-11-11 12:24:36,071] trace_parser.py:107 [WARNING]: Parsed ~/traces/trace_kineto.0.json time = 0.07 seconds
[2024-11-11 12:24:36,086] trace_parser.py:317 [WARNING]: Rounding down ns resolution events due to issue with events overlapping. ts dtype = float64, dur dtype = float64.Please see https://github.com/pytorch/pytorch/pull/122425
[2024-11-11 12:24:36,127] trace_parser.py:430 [WARNING]: Parsed ~/traces/trace_kineto.0.json backend=ParserBackend.JSON in 0.13 seconds; current PID:3256
[2024-11-11 12:24:36,148] trace.py:236 [WARNING]: Overall parsing of ~/traces/trace_kineto.0.json in 0.15 seconds; current PID:3256
[2024-11-11 12:24:36,151] trace.py:449 [WARNING]: leaving parse_multiple_ranks duration=0.15 seconds
[2024-11-11 12:24:36,151] trace.py:483 [WARNING]: leaving parse_traces duration=0.15 seconds
[2024-11-11 12:24:36,151] trace.py:654 [WARNING]: There is only one iteration in the trace. The analysis result may not be accurate.
[2024-11-11 12:24:36,152] critical_path_analysis.py:1467 [WARNING]: Trace does not contain CUDA Synchronization events so the results of analysis could be inaccurate.
[2024-11-11 12:24:36,152] critical_path_analysis.py:1471 [WARNING]: Please see this PR to learn how to enable CUDA sync events https://github.com/pytorch/pytorch/pull/105187
[2024-11-11 12:24:36,152] critical_path_analysis.py:1493 [INFO]: Looking up events under [0, 0) instance(s) of 'ProfilerStep' annotation.
[2024-11-11 12:24:36,153] critical_path_analysis.py:1509 [INFO]: Looking up events within the window (1859, 1400577.0)
[2024-11-11 12:24:36,161] critical_path_analysis.py:1533 [INFO]: Clipped dataframe has 7575 events
[2024-11-11 12:24:36,163] critical_path_analysis.py:1540 [INFO]: Preprocessing took 0.01 seconds
[2024-11-11 12:24:36,445] critical_path_analysis.py:1544 [INFO]: CPGraph construction took 0.28 seconds
[2024-11-11 12:24:36,448] critical_path_analysis.py:1171 [WARNING]: Ignoring negative weight of -1 for CPEdge(begin=9022, end=9023, weight=np.float64(-1.0), type=<CPEdgeType.OPERATOR_KERNEL: 'critical_path_operator'>)
[2024-11-11 12:24:36,448] critical_path_analysis.py:1171 [WARNING]: Ignoring negative weight of -1 for CPEdge(begin=9032, end=9033, weight=np.float64(-1.0), type=<CPEdgeType.OPERATOR_KERNEL: 'critical_path_operator'>)
[2024-11-11 12:24:36,448] critical_path_analysis.py:1171 [WARNING]: Ignoring negative weight of -1 for CPEdge(begin=9220, end=9221, weight=np.float64(-1.0), type=<CPEdgeType.OPERATOR_KERNEL: 'critical_path_operator'>)
[2024-11-11 12:24:36,448] critical_path_analysis.py:1171 [WARNING]: Ignoring negative weight of -1 for CPEdge(begin=9286, end=9287, weight=np.float64(-1.0), type=<CPEdgeType.OPERATOR_KERNEL: 'critical_path_operator'>)
[2024-11-11 12:24:36,448] critical_path_analysis.py:1171 [WARNING]: Ignoring negative weight of -1 for CPEdge(begin=9362, end=9363, weight=np.float64(-1.0), type=<CPEdgeType.OPERATOR_KERNEL: 'critical_path_operator'>)
[2024-11-11 12:24:36,468] critical_path_analysis.py:1143 [INFO]: calculating critical path took 0.023477 seconds
[2024-11-11 12:24:36,490] trace_parser.py:107 [WARNING]: Parsed ~/traces/trace_kineto.0.json time = 0.02 seconds
[2024-11-11 12:24:36,492] trace_linker.py:280 [INFO]: Enforcing sync order in Kineto traces.
[2024-11-11 12:24:36,492] trace_linker.py:326 [INFO]: Thread PyTorch Profiler: Identifying synchronization dependency.
[2024-11-11 12:24:36,492] trace_linker.py:326 [INFO]: Thread 0: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread Trace PyTorch Profiler: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 17810: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 17809: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 17808: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 17779: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 7: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread 17841: Identifying synchronization dependency.
[2024-11-11 12:24:36,493] trace_linker.py:326 [INFO]: Thread : Identifying synchronization dependency.
[2024-11-11 12:24:37,150] trace_link.py:49 [INFO]: Linking process successful. Output file is available at trace_linked.0.json.
[2024-11-11 12:24:37,150] trace_link.py:50 [INFO]: Please run the chakra_converter for further postprocessing.
```

</details>
