### PR TITLE
Added Kernel Launch Op names for AMD GPUs

### DIFF
--- a/src/trace_link/kineto_operator.py
+++ b/src/trace_link/kineto_operator.py
@@ -147,7 +147,16 @@ class KinetoOperator:
             "cudaMemcpyToSymbol",
             "cudaLaunchCooperativeKernel",
         }
-        return cuda_launch_categories and self.name in cuda_launch_operations
+
+        hip_launch_operations = {
+            "hipLaunchKernel",
+            "hipExtLaunchKernel",
+            "hipExtModuleLaunchKernel",
+            "hipModuleLaunchKernel",
+            "hipMemcpyWithStream",
+            "hipMemcpyAsync",
+        }
+        return cuda_launch_categories and (self.name in cuda_launch_operations or self.name in hip_launch_operations)
 
     def is_gpu_op(self) -> bool:
         """


### PR DESCRIPTION
## Summary
Added Kernel Op names from HIP such as hipLaunchKernel, hipMemCpy, etc so that Chakra can work with AMD Traces.

In order to run the chakra trace linker on AMD devices, a similar PR must be made to HTA too, since the critical path analyzer from HTA is used in the chakra_trace_link function. A PR is posted to HTA (https://github.com/facebookresearch/HolisticTraceAnalysis/pull/225) and updated here soon. In the meantime, this patch can be used in the hta source directory as shown in the PR discussion to enable AMD GPUs.

## Detailed Description
In the Chakra Trace Linker, the is_kernel_launch_op() checks if a given op is a kernel launch op by comparing the op name against a set of cuda specific launch kernel names. In order for Chakra to work with AMD Kineto Traces, this has been updated to include the corresponding HIP launch event names. This has been done in such a way that it does not disrupt the original execution for Nvidia devices.

## Test Plan:

The commit passes all the GitHub automation tests. 
For verifying correctness, three models were profiled for one inference run on an AMD Instinct MI250 GPU and the chakra linker was used on the generated ET and Kineto traces:

1. Matrix Multiplication example code from the Chakra Wiki [found here](https://github.com/mlcommons/chakra/wiki/Chakra-Execution-Trace-Collection-%E2%80%90-A-Comprehensive-Guide-on-Merging-PyTorch-and-Kineto-Traces#simultaneous-collection-of-pytorch-execution-and-kineto-traces)
2. Toy example 

```
class ToyModel(nn.Module):
  def __init__(self):
    super(ToyModel, self).__init__()
    self.layers = nn.ModuleList([nn.Linear(128, 128)])
    self.layers.append(nn.ReLU())
  
  def forward(self, x):
    for layer in self.layers:
      x = layer(x)
      return x
```

3. Longformer [from Huggingface Transformers](https://huggingface.co/docs/transformers/model_doc/longformer)

Command: 
```
chakra_trace_link --rank 0 --chakra-host-trace ./pytorch_et.json --chakra-device-trace ./kineto_trace.json --output-file ./linked.json
```

Final Output: (without any warnings)
```
...
trace_link.py:49 [INFO]: Linking process successful. Output file is available at ./linked.json.
trace_link.py:50 [INFO]: Please run the chakra_converter for further postprocessing. 
```