### PR TITLE
Trim file path from Kineto File name to avoid errors when running from another directory

### DIFF
--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -117,6 +117,7 @@ class TraceLinker:
         sync_dependencies = {}
         absolute_kineto_file = os.path.abspath(kineto_file)
         trace_dir = os.path.dirname(absolute_kineto_file)
+        kineto_file = os.path.basename(kineto_file)
         trace_analysis = TraceAnalysis(trace_dir=trace_dir, trace_files={rank: kineto_file})
         cp_graph, success = trace_analysis.critical_path_analysis(
             rank=rank, annotation=annotation, instance_id=instance_id


### PR DESCRIPTION
## Summary
Using the chakra_trace_link command from a directory other than the one where the Kineto trace is stored raises an error. This is because the absolute file path is directly appended to the argument passed with --chakra-device-trace. The solution is to sanitize the input so that the --chakra-device-trace does not contain any path, just the base file name. This way, the chakra_trace_link command can be used from both the same directory as the Kineto file, as well as any other directory. This is a necessary change when traces from different devices/runs are stored in separate folders. 

## Test Plan
- Tested on PACE ICE (RHEL 9.4).
- Test chakra_trace_link on any trace, in two ways: inside the /logs directory which stores the traces, as well as from outside the /logs directory, passing appropriate path inputs to the chakra_trace_link command.
