### PR TITLE
do not overwrite gpu op timestamp with runtime op timestamp

### DIFF
--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -679,8 +679,6 @@ class TraceLinker:
             f"Found CUDA runtime operation '{kineto_runtime_op.name}' for GPU operator '{kineto_gpu_op.name}'."
         )
 
-        kineto_gpu_op.timestamp = kineto_runtime_op.timestamp
-
         # Find the closest CPU operator that precedes the CUDA runtime operation
         parent_cpu_op = self.find_closest_op(
             kineto_gpu_op, sorted_kineto_cpu_ops, sorted_kineto_cpu_op_ts, kineto_runtime_op.timestamp


### PR DESCRIPTION

 some overlapping collectives occur because the timestamp of the GPU operation is overwritten with the timestamp of the runtime operation.

I dumped some relevant info from the device trace and from the resulting linked trace, where not only an overlap is noticeable, but also a mismatch between the starting/ending timestamps:
Kineto:
start:23:25:28.743436 duration:8932.93 end:23:25:28.752369 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start:23:25:28.755013 duration:31272.55 end:23:25:28.786285 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start:23:25:28.786286 duration:22644.126 end:23:25:28.808930 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start:23:25:28.809750 duration:42481.079 end:23:25:28.852232 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start:23:25:28.871565 duration:44283.024 end:23:25:28.915848 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
Linked:
start: 23:25:28.743424 duration: 8932.93 \ end:23:25:28.752357 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start: 23:25:28.754414 duration: 31272.55 \ end:23:25:28.785686 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start: 23:25:28.759648 duration: 22644.126 \ end:23:25:28.782292 overlapped:True ncclDevKernel_AllReduce_Sum_f32_RING_LL
start: 23:25:28.807910 duration: 42481.079 \ end:23:25:28.850391 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL
start: 23:25:28.858260 duration: 44283.024 \ end:23:25:28.902543 overlapped:False ncclDevKernel_AllReduce_Sum_f32_RING_LL

