### PR TITLE
preserve collectives

### DIFF
--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -50,7 +50,8 @@ class PyTorchConverter:
         for root_node in root_node_list:
             self.convert_ctrl_dep_to_data_dep(json_node_map, protobuf_node_map, root_node)
 
-        protobuf_node_map = self.remove_dangling_nodes(protobuf_node_map)
+        # do not remove secondary connected components
+        # protobuf_node_map = self.remove_dangling_nodes(protobuf_node_map)
 
         parent_to_children_map = self.update_parent_to_children_map(protobuf_node_map)
 

--- a/src/converter/pytorch_converter.py
+++ b/src/converter/pytorch_converter.py
@@ -50,8 +50,7 @@ class PyTorchConverter:
         for root_node in root_node_list:
             self.convert_ctrl_dep_to_data_dep(json_node_map, protobuf_node_map, root_node)
 
-        # do not remove secondary connected components
-        # protobuf_node_map = self.remove_dangling_nodes(protobuf_node_map)
+        protobuf_node_map = self.remove_dangling_nodes(protobuf_node_map)
 
         parent_to_children_map = self.update_parent_to_children_map(protobuf_node_map)
 

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -23,6 +23,7 @@ class ChakraHostTraceLoader:
         Args:
             chakra_host_trace_file (str): Path to the PyTorch execution trace file.
             connect_host_trace (bool): Connect host nodes with missing parents to the corresponding thread root node.
+
         Returns:
             Tuple[List[PyTorchOperator], Dict[str, Any]]: Tuple containing list of PyTorch operators and host trace.
         """
@@ -48,6 +49,7 @@ class ChakraHostTraceLoader:
 
         Args:
             node (PyTorchOperator): Starting node for extraction.
+
         Returns:
             List[PyTorchOperator]: Sorted list of extracted PyTorchOperator nodes.
         """
@@ -65,12 +67,14 @@ class ChakraHostTraceLoader:
     def _create_host_ops(self, host_trace: Dict[str, Any], connect_host_trace: bool) -> Dict[int, PyTorchOperator]:
         """
         Create host operators from the provided host trace.
+        
         This method processes the host trace, extracts nodes, and creates PyTorchOperator instances based on the schema
         version specified in the host trace.
 
         Args:
             host_trace (Dict[str, Any]): The host trace dictionary.
             connect_host_trace (bool): Connect host nodes with missing parents to the corresponding thread root node.
+
         Returns:
             Dict[int, PyTorchOperator]: A dictionary mapping operator IDs to PyTorchOperator instances.
         """
@@ -119,9 +123,10 @@ class ChakraHostTraceLoader:
         Get the operator creation method for the specified schema version.
         
         Args:
-            schema (str): The schema version of the host trace.   
+            schema (str): The schema version of the host trace. 
+
         Returns:
-            Callable[[int, Dict[str, Any]], PyTorchOperator] | None: The operator creation functor for the schema version,
+            Callable[[int, Dict[str, Any]], PyTorchOperator] | None: Operator creation functor for the schema version,
             or None if no functor is found.
         """
         node_creation_func = {

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -25,8 +25,14 @@ class ChakraHostTraceLoader:
         logging.debug(f"Starting to load Chakra host execution trace from file: {chakra_host_trace_file}.")
         chakra_host_trace = load_execution_trace_file(chakra_host_trace_file)
 
-        root_node = chakra_host_trace.get_nodes()[1]  # Root node is usually 1-based
-        chakra_host_ops = self.extract_chakra_host_ops(root_node)
+        # root_node = chakra_host_trace.get_nodes()[1]  # Root node is usually 1-based
+        # chakra_host_ops = self.extract_chakra_host_ops(root_node)
+        
+        # also include orphaned node belonging secondary connected components
+        chakra_host_ops = []
+        for host_op in chakra_host_trace.get_nodes().values():
+            chakra_host_ops.append(host_op)
+
         logging.debug(f"Extracted {len(chakra_host_ops)} operators from Chakra host execution trace.")
         logging.debug("Chakra host execution trace has been loaded and processed successfully.")
 

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from typing import Any, Callable, Dict, List, Tuple
 
-from et_replay.execution_trace import EXECUTION_TRACE_THREAD_ANNOTATION
+from et_replay.execution_trace import EXECUTION_TRACE_THREAD_ANNOTATION as THREAD_ANNOTATION
 from et_replay.execution_trace import ExecutionTrace as PyTorchTrace
 from et_replay.execution_trace import Node as PyTorchOperator
 from et_replay.utils import read_dictionary_from_json_file
@@ -14,19 +14,67 @@ sys.setrecursionlimit(10**6)
 class ChakraHostTraceLoader:
     """Loads Chakra host traces."""
 
-    def load(self, chakra_host_trace_file: str) -> Tuple[List[PyTorchOperator], Dict[str, Any]]:
+    def load(self,
+        chakra_host_trace_file: str,
+        connect_host_trace: bool) -> Tuple[List[PyTorchOperator], Dict[str, Any]]:
         """
         Load and process the Chakra Host Execution Trace.
 
         Args:
             chakra_host_trace_file (str): Path to the PyTorch execution trace file.
-
+            connect_host_trace (bool): Connect host nodes with missing parents to the corresponding thread root node.
         Returns:
             Tuple[List[PyTorchOperator], Dict[str, Any]]: Tuple containing list of PyTorch operators and host trace.
         """
         logging.debug(f"Starting to load Chakra host execution trace from file: {chakra_host_trace_file}.")
         host_trace = read_dictionary_from_json_file(chakra_host_trace_file)
 
+        host_ops = self._create_host_ops(host_trace, connect_host_trace)
+        root_node = host_ops.get(1) # Root node is usually 1-based
+        
+        chakra_host_ops = self.extract_chakra_host_ops(root_node)
+
+        logging.debug(f"Extracted {len(chakra_host_ops)} operators from Chakra host execution trace.")
+        logging.debug("Chakra host execution trace has been loaded and processed successfully.")
+
+        return chakra_host_ops, host_trace
+
+    def extract_chakra_host_ops(self, node: PyTorchOperator) -> List[PyTorchOperator]:
+        """
+        Extract and sort nodes from the PyTorch execution trace recursively.
+
+        This method traverses the execution trace starting from the provided node, extracting all the operator nodes
+        recursively, and then returns them sorted by their identifiers.
+
+        Args:
+            node (PyTorchOperator): Starting node for extraction.
+        Returns:
+            List[PyTorchOperator]: Sorted list of extracted PyTorchOperator nodes.
+        """
+        nodes = []
+
+        def traverse(node: PyTorchOperator):
+            nodes.append(node)
+            for child in node.children:
+                traverse(child)
+
+        traverse(node)
+        logging.debug(f"Traversed {len(nodes)} nodes from root node ID: {node.id}")
+        return sorted(nodes, key=lambda x: x.id)
+
+    def _create_host_ops(self, host_trace: Dict[str, Any], connect_host_trace: bool) -> Dict[int, PyTorchOperator]:
+        """
+        Create host operators from the provided host trace.
+        This method processes the host trace, extracts nodes, and creates PyTorchOperator instances based on the schema
+        version specified in the host trace.
+
+        Args:
+            host_trace (Dict[str, Any]): The host trace dictionary.
+            connect_host_trace (bool): Connect host nodes with missing parents to the corresponding thread root node.
+        Returns:
+            Dict[int, PyTorchOperator]: A dictionary mapping operator IDs to PyTorchOperator instances.
+        """
+        
         schema: str = host_trace["schema"]
         pid: int = host_trace["pid"]
         nodes: List[Dict[str, Any]] = host_trace["nodes"]
@@ -40,33 +88,42 @@ class ChakraHostTraceLoader:
         host_ops: Dict[int, PyTorchOperator] = {}
         thread_roots: Dict[int, int] = {}
         for node in nodes:
-            op = create_operator(pid, node)
-            if op.parent_id == 1 and EXECUTION_TRACE_THREAD_ANNOTATION in op.name:
-                thread_roots[op.tid] = op.id
-            host_ops[op.id] = op
+            host_op = create_operator(pid, node)
+            host_ops[host_op.id] = host_op
+            if host_op.parent_id == 1 and THREAD_ANNOTATION in host_op.name:
+                thread_roots[host_op.tid] = host_op.id
 
-        for op in host_ops.values():
-            if op.parent_id not in host_ops:             
-                parent_id = thread_roots.get(op.tid, None)
+        for host_op in host_ops.values():
+            if host_op.parent_id in host_ops and host_op.id != 1:
+                parent = host_ops[host_op.parent_id]
+                host_op.set_parent(parent)
+                parent.add_child(host_op)
+            elif connect_host_trace is True: # connect orphans to the thread root
+                parent_id = thread_roots.get(host_op.tid, None)
                 if parent_id is not None:
-                    op.parent_id = parent_id
-                    op.set_parent(host_ops[parent_id])
-                    host_ops[parent_id].add_child(op)
-                    node = next(filter(lambda n: n["id"] == op.id, nodes), None)
+                    host_op.parent_id = parent_id
+                    parent = host_ops[parent_id]
+                    host_op.set_parent(parent)
+                    parent.add_child(host_op)
+                    node = next(filter(lambda n: n["id"] == host_op.id, nodes), None)
                     if node is not None:
                         node["ctrl_deps"] = parent_id
         
-        for op in host_ops.values():
-            op.sort_children()
-        
-        chakra_host_ops = sorted(host_ops.values(), key=lambda x: x.id)
+        for host_op in host_ops.values():
+            host_op.sort_children()
 
-        logging.debug(f"Extracted {len(chakra_host_ops)} operators from Chakra host execution trace.")
-        logging.debug("Chakra host execution trace has been loaded and processed successfully.")
-
-        return chakra_host_ops, host_trace
-
+        return host_ops
+    
     def _get_operator_creation_method(self, schema: str) -> Callable[[int, Dict[str, Any]], PyTorchOperator] | None:
+        """
+        Get the operator creation method for the specified schema version.
+        
+        Args:
+            schema (str): The schema version of the host trace.   
+        Returns:
+            Callable[[int, Dict[str, Any]], PyTorchOperator] | None: The operator creation functor for the schema version,
+            or None if no functor is found.
+        """
         node_creation_func = {
             "1.0.1": PyTorchTrace._create_node_v1_0_1,
             "1.0.2-chakra.0.0.4": PyTorchTrace._create_node_v1_0_2_chakra_0_0_4,

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -1,9 +1,11 @@
 import logging
 import sys
-from typing import List
+from typing import Any, Callable, Dict, List, Tuple
 
 from et_replay.execution_trace import Node as PyTorchOperator
-from et_replay.utils import load_execution_trace_file
+from et_replay.execution_trace import ExecutionTrace as PyTorchTrace
+from et_replay.execution_trace import EXECUTION_TRACE_THREAD_ANNOTATION
+from et_replay.utils import read_dictionary_from_json_file
 
 # Increase the recursion limit for deep Chakra host execution traces.
 sys.setrecursionlimit(10**6)
@@ -12,7 +14,7 @@ sys.setrecursionlimit(10**6)
 class ChakraHostTraceLoader:
     """Loads Chakra host traces."""
 
-    def load(self, chakra_host_trace_file: str) -> List[PyTorchOperator]:
+    def load(self, chakra_host_trace_file: str) -> Tuple[List[PyTorchOperator], Dict[str, Any]]:
         """
         Load and process the Chakra Host Execution Trace.
 
@@ -20,44 +22,62 @@ class ChakraHostTraceLoader:
             chakra_host_trace_file (str): Path to the PyTorch execution trace file.
 
         Returns:
-            List[PyTorchOperator]: List of PyTorch operators.
+            Tuple[List[PyTorchOperator], Dict[str, Any]]: A tuple containing a list of PyTorch operators and a host trace.
         """
         logging.debug(f"Starting to load Chakra host execution trace from file: {chakra_host_trace_file}.")
-        chakra_host_trace = load_execution_trace_file(chakra_host_trace_file)
+        host_trace = read_dictionary_from_json_file(chakra_host_trace_file)
 
-        # root_node = chakra_host_trace.get_nodes()[1]  # Root node is usually 1-based
-        # chakra_host_ops = self.extract_chakra_host_ops(root_node)
+        schema: str = host_trace["schema"]
+        pid: int = host_trace["pid"]
+        nodes: List[Dict[str, Any]] = host_trace["nodes"]
+
+        create_operator = self._get_operator_creation_method(schema)
+        if create_operator is None:
+            raise ValueError(
+                f"No corresponding node creation function found for schema version {schema}"
+            )
         
-        # also include orphaned node belonging secondary connected components
-        chakra_host_ops = []
-        for host_op in chakra_host_trace.get_nodes().values():
-            chakra_host_ops.append(host_op)
+        host_ops: Dict[int, PyTorchOperator] = {}
+        thread_roots: Dict[int, int] = {}
+        for node in nodes:
+            op = create_operator(pid, node)
+            if op.parent_id == 1 and EXECUTION_TRACE_THREAD_ANNOTATION in op.name:
+                thread_roots[op.tid] = op.id
+            host_ops[op.id] = op
+
+        for op in host_ops.values():
+            if op.parent_id not in host_ops:             
+                parent_id = thread_roots.get(op.tid, None)
+                if parent_id is not None:
+                    op.parent_id = parent_id
+                    op.set_parent(host_ops[parent_id])
+                    host_ops[parent_id].add_child(op)
+                    node = next(filter(lambda n: n["id"] == op.id, nodes), None)
+                    if node is not None:
+                        node["ctrl_deps"] = parent_id
+        
+        for op in host_ops.values():
+            op.sort_children()
+        
+        chakra_host_ops = sorted(host_ops.values(), key=lambda x: x.id)
 
         logging.debug(f"Extracted {len(chakra_host_ops)} operators from Chakra host execution trace.")
         logging.debug("Chakra host execution trace has been loaded and processed successfully.")
 
-        return chakra_host_ops
+        return chakra_host_ops, host_trace
 
-    def extract_chakra_host_ops(self, node: PyTorchOperator) -> List[PyTorchOperator]:
-        """
-        Extract and sort nodes from the PyTorch execution trace recursively.
-
-        This method traverses the execution trace starting from the provided node, extracting all the operator nodes
-        recursively, and then returns them sorted by their identifiers.
-
-        Args:
-            node (PyTorchOperator): Starting node for extraction.
-
-        Returns:
-            List[PyTorchOperator]: Sorted list of extracted PyTorchOperator nodes.
-        """
-        nodes = []
-
-        def traverse(node: PyTorchOperator):
-            nodes.append(node)
-            for child in node.children:
-                traverse(child)
-
-        traverse(node)
-        logging.debug(f"Traversed {len(nodes)} nodes from root node ID: {node.id}")
-        return sorted(nodes, key=lambda x: x.id)
+    def _get_operator_creation_method(self, schema: str) -> Callable[[int, Dict[str, Any]], PyTorchOperator] | None:
+        node_creation_func = {
+            "1.0.1": PyTorchTrace._create_node_v1_0_1,
+            "1.0.2-chakra.0.0.4": PyTorchTrace._create_node_v1_0_2_chakra_0_0_4,
+            # 1.0.3 expands pg name to <pg_name, pg_desc> so it use the same parser as 1.0.2
+            "1.0.3-chakra.0.0.4": PyTorchTrace._create_node_v1_0_2_chakra_0_0_4,
+            # 1.0.4 adds PT2 kernel backend and kernel file
+            "1.0.4-chakra.0.0.4": PyTorchTrace._create_node_v1_0_2_chakra_0_0_4,
+            # 1.1.0 includes new comm args in record_param_comms
+            "1.1.0-chakra.0.0.4": PyTorchTrace._create_node_v1_0_2_chakra_0_0_4,
+            # 1.1.1 includes tensor strides
+            "1.1.1-chakra.0.0.4": PyTorchTrace._create_node_v1_1_1_chakra_0_0_4,
+            # Add future versions here
+        }
+        return node_creation_func.get(schema, None)

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -2,9 +2,9 @@ import logging
 import sys
 from typing import Any, Callable, Dict, List, Tuple
 
-from et_replay.execution_trace import Node as PyTorchOperator
-from et_replay.execution_trace import ExecutionTrace as PyTorchTrace
 from et_replay.execution_trace import EXECUTION_TRACE_THREAD_ANNOTATION
+from et_replay.execution_trace import ExecutionTrace as PyTorchTrace
+from et_replay.execution_trace import Node as PyTorchOperator
 from et_replay.utils import read_dictionary_from_json_file
 
 # Increase the recursion limit for deep Chakra host execution traces.
@@ -22,7 +22,7 @@ class ChakraHostTraceLoader:
             chakra_host_trace_file (str): Path to the PyTorch execution trace file.
 
         Returns:
-            Tuple[List[PyTorchOperator], Dict[str, Any]]: A tuple containing a list of PyTorch operators and a host trace.
+            Tuple[List[PyTorchOperator], Dict[str, Any]]: Tuple containing list of PyTorch operators and host trace.
         """
         logging.debug(f"Starting to load Chakra host execution trace from file: {chakra_host_trace_file}.")
         host_trace = read_dictionary_from_json_file(chakra_host_trace_file)
@@ -80,4 +80,4 @@ class ChakraHostTraceLoader:
             "1.1.1-chakra.0.0.4": PyTorchTrace._create_node_v1_1_1_chakra_0_0_4,
             # Add future versions here
         }
-        return node_creation_func.get(schema, None)
+        return node_creation_func.get(schema)

--- a/src/trace_link/chakra_host_trace_loader.py
+++ b/src/trace_link/chakra_host_trace_loader.py
@@ -77,8 +77,7 @@ class ChakraHostTraceLoader:
 
         Returns:
             Dict[int, PyTorchOperator]: A dictionary mapping operator IDs to PyTorchOperator instances.
-        """
-        
+        """ 
         schema: str = host_trace["schema"]
         pid: int = host_trace["pid"]
         nodes: List[Dict[str, Any]] = host_trace["nodes"]

--- a/src/trace_link/trace_link.py
+++ b/src/trace_link/trace_link.py
@@ -37,6 +37,11 @@ def main() -> None:
         required=True,
         help="Path for the output Chakra host + device trace in the JSON format",
     )
+    parser.add_argument("--connect-host-trace",
+        type=bool,
+        default=False,
+        help="Whether to connect host nodes with missing parents to the corresponding thread root node.",
+    )
     parser.add_argument("--log-level", default="INFO", type=str, help="Log output verbosity level")
 
     args = parser.parse_args()
@@ -44,7 +49,7 @@ def main() -> None:
     logging.basicConfig(level=args.log_level.upper())
 
     linker = TraceLinker()
-    linker.link(args.rank, args.chakra_host_trace, args.chakra_device_trace, args.output_file)
+    linker.link(args.rank, args.chakra_host_trace, args.chakra_device_trace, args.output_file, args.connect_host_trace)
 
     logging.info(f"Linking process successful. Output file is available at {args.output_file}.")
     logging.info("Please run the chakra_converter for further postprocessing.")

--- a/src/trace_link/trace_linker.py
+++ b/src/trace_link/trace_linker.py
@@ -36,7 +36,11 @@ class TraceLinker:
         self.chakra_device_trace_loader = ChakraDeviceTraceLoader()
         self.id_assigner = UniqueIdAssigner()
 
-    def link(self, rank: int, chakra_host_trace: str, chakra_device_trace: str, output_file: str) -> None:
+    def link(self, rank: int,
+        chakra_host_trace: str,
+        chakra_device_trace: str,
+        output_file: str,
+        connect_host_trace: bool) -> None:
         """
         Links Chakra host execution traces (ET) and Chakra device ET to generate Chakra host + device ET.
 
@@ -45,8 +49,9 @@ class TraceLinker:
             chakra_host_trace (str): Path to the Chakra host execution trace file.
             chakra_device_trace (str): Path to the Kineto trace file.
             output_file (str): Path for the output nyTorch execution trace plus file.
+            connect_host_trace (bool): Connect host nodes with missing parents to the corresponding thread root node.
         """
-        host_ops, host_trace = self.chakra_host_trace_loader.load(chakra_host_trace)
+        host_ops, host_trace = self.chakra_host_trace_loader.load(chakra_host_trace, connect_host_trace)
 
         (
             kineto_cpu_ops,

--- a/tests/trace_link/test_trace_linker.py
+++ b/tests/trace_link/test_trace_linker.py
@@ -594,7 +594,7 @@ def test_construct_et_plus_data(mock_json_load, mock_open, mock_process_op_and_d
     host_op_id_to_inter_thread_dep_map = {1: None, 2: None}
 
     pytorch_et_plus_data = trace_linker.construct_et_plus_data(
-        "path/to/pytorch_et_file",
+        mock_json_load.return_value,
         host_op_id_to_kineto_ops_map,
         host_op_id_to_inclusive_dur_map,
         host_op_id_to_exclusive_dur_map,


### PR DESCRIPTION
Mostly addressing https://github.com/mlcommons/chakra/issues/161
Issue: some collectives are missing from the .et file, but are present in the kineto file.

It all starts from the host trace, these missing collectives have host operations with missing parents. To be more specific, the host ops corresponding to these collectives have a parent which is not part of the p_trace file.
Specific example:
host_op1: { id: 439, name: "record_param_comms", ctrl_deps: 438, rf_id: 115 } -> this corresponds to a ncclDevKernel_Broadcast
host_op2: { id: 438, name: "c10d::broadcast_", ctrl_deps: 9 }
host_op3: { id: 9, name: "DistributedDataParallel.forward", ctrl_deps: 4 }

So, host_op1 has host_op2 as parent, host_op2 has host_op3 as parent, and host_op3 has a node with id 4 as parent.
However, host op with id: 4 is not present in the p_trace_file and so facebookresearch/param/et_replay will not properly build the children/parent links (as seen in execution_trace.py):
if n.parent_id in self.nodes: # here there is no node with id equal to parent_id in the list of nodes
    self.nodes[n.parent_id].add_child(n)
    n.set_parent(self.nodes[n.parent_id])
When chakra loads the host trace, it will do a traversal starting from the root_node, but since there are some nodes which have parents not present in the file, this trace will be a graph with multiple components => chakra will load the "main" connected component, the one starting from the root node. For example, for a ResNet50 on 4 ranks that I've used to debug, it will load 2410/4484 host op nodes. 

Attaching several relevant files generated with and without the changes from this branch.
[p_trace_rank0.json](https://github.com/user-attachments/files/19492736/p_trace_rank0.json)
[kineto_trace_rank0.json](https://github.com/user-attachments/files/19492737/kineto_trace_rank0.json)
[new_jsonized_chakra_trace.json](https://github.com/user-attachments/files/19492738/new_jsonized_chakra_trace.json)
[new_merged.json](https://github.com/user-attachments/files/19492739/new_merged.json)
[old_jsonized_chakra_trace.json](https://github.com/user-attachments/files/19492734/old_jsonized_chakra_trace.json)
[old_merged.json](https://github.com/user-attachments/files/19492735/old_merged.json)

cc: @winstonliu1111 @danmih-ixia @TaekyungHeo @tushar-krishna 
