### PR TITLE
Update protobuf dependency to use most recent version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "MLCommons", email = "chakra@mlcommons.org"},
 ]
 dependencies = [
-    "protobuf==5.*",
+    "protobuf",
     "graphviz",
     "networkx",
     "pydot",


### PR DESCRIPTION
## Summary
Refer to #195
Update `pyproject.toml` to use most recent protobuf, instead of capping at `5.*`
This has an inherent risk of the bleeding edge protobuf breaking Chakra.

## Test Plan
```bash
pip install -e .
pip show protobuf | grep Version
Version: 5.29.5
chakra_generator
#.... Error message


# In a new conda environment
# Apply this PR
pip install -e .
pip show protobuf | grep Version 
Version: 6.31.1
chakra_generator
# No error message
```

## Additional Notes
I still believe the long term solution to this issue is, during `pip install .`/`pyproject.toml`,  not to use `grpc_tools.protoc` that forces a version update on its own schedule.