### PR TITLE
Default num_ops_ to 0

### DIFF
--- a/src/feeder/et_feeder_node.cpp
+++ b/src/feeder/et_feeder_node.cpp
@@ -9,6 +9,7 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
   this->name_ = node->name();
   this->runtime_ = node->duration_micros();
   this->is_cpu_op_ = 0;
+  this->num_ops_ = 0;
 
   if (node->has_inputs()) {
     this->inputs_values_ = static_cast<string>(node->inputs().values());


### PR DESCRIPTION
## Summary
It was noticed that the debug and realease build were incoherent in terms of execution flow. The reason was narrowed down to num_ops_ being uninitialized, which triggered the astra-sim to take a different branch here:
https://github.com/astra-sim/astra-sim/blob/tutorial-hoti2024/astra-sim/workload/Workload.cc#L126

## Test Plan
Run gcc sanitizer and check if the value is initialized.

